### PR TITLE
[SWWW switcher] Add support for post script to be runned after wallpaper is set,

### DIFF
--- a/extensions/swww-switcher/package.json
+++ b/extensions/swww-switcher/package.json
@@ -190,6 +190,14 @@
       "default": "90"
     },
     {
+      "name": "postScriptPath",
+      "title": "Post wallpaper change script",
+      "description": "A script provided by the user to be executed after the wallpaper change, with the wallpaper absolute path as the first argument",
+      "required": false,
+      "type": "textfield",
+      "default": ""
+    },
+    {
       "name": "colorGenTool",
       "title": "Color Generator",
       "description": "Which color generation tool do you use?",

--- a/extensions/swww-switcher/src/utils/hyprland.ts
+++ b/extensions/swww-switcher/src/utils/hyprland.ts
@@ -12,6 +12,7 @@ export async function omniCommand(
   apptoggle: boolean,
   colorApp: string,
   postProduction: string,
+  userPostScript: string,
 ) {
   let success: boolean;
 
@@ -81,6 +82,23 @@ export async function omniCommand(
         });
       }
     }
+
+    if (userPostScript != "") {
+      const userPostScriptSuccess = await postScript(path, userPostScript);
+
+      if (userPostScriptSuccess) {
+        const msg: string = "Wall set";
+        showToast({
+          style: Toast.Style.Success,
+          title: "Wall set, user script done!",
+        });
+      } else {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "User script failed",
+        });
+      }
+    }
   } else {
     showToast({
       style: Toast.Style.Failure,
@@ -145,4 +163,23 @@ export const setWallpaperOnMonitor = async (
 };
 export const toggleVicinae = (): void => {
   exec(`vicinae vicinae://toggle`);
+};
+
+export const postScript = async (
+  img_path: string,
+  user_post_scrript: string,
+): Promise<boolean> => {
+  try {
+    return await new Promise<boolean>((resolve) => {
+      exec(`${user_post_scrript} ${img_path}`, (error) => {
+        if (error) {
+          resolve(false);
+        } else {
+          resolve(true);
+        }
+      });
+    });
+  } catch (error) {
+    return false;
+  }
 };

--- a/extensions/swww-switcher/src/wpgrid.tsx
+++ b/extensions/swww-switcher/src/wpgrid.tsx
@@ -32,6 +32,7 @@ export default function DisplayGrid() {
   const postProduction = getPreferenceValues().postProduction;
   const leftMonitorName: string = getPreferenceValues().leftMonitor;
   const rightMonitorName: string = getPreferenceValues().rightMonitor;
+  const postScriptPath: string = getPreferenceValues().postScriptPath;
 
   const [wallpapersPath, setWallpapersPath] = useState<string | null>(null);
   const [wallpapers, setWallpapers] = useState<Image[]>([]);
@@ -109,6 +110,7 @@ export default function DisplayGrid() {
                             preferences.toggleVicinaeSetting,
                             colorGen,
                             postProduction,
+                            postScriptPath,
                           );
                         }}
                       />
@@ -130,6 +132,7 @@ export default function DisplayGrid() {
                                 preferences.toggleVicinaeSetting,
                                 colorGen,
                                 postProduction,
+                                postScriptPath,
                               );
                             }}
                           />
@@ -152,6 +155,7 @@ export default function DisplayGrid() {
                               preferences.toggleVicinaeSetting,
                               colorGen,
                               postProduction,
+                              postScriptPath,
                             );
                           }}
                         />

--- a/extensions/swww-switcher/src/wprandom.tsx
+++ b/extensions/swww-switcher/src/wprandom.tsx
@@ -18,6 +18,7 @@ export default async function RandomWallpaper() {
   const leftMonitorName: string = getPreferenceValues().leftMonitor;
   const rightMonitorName: string = getPreferenceValues().rightMonitor;
   const postProduction = getPreferenceValues().postProduction;
+  const postScriptPath: string = getPreferenceValues().postScriptPath;
 
   try {
     await showToast({
@@ -57,6 +58,7 @@ export default async function RandomWallpaper() {
         preferences.toggleVicinaeSetting,
         colorGen,
         postProduction,
+        postScriptPath,
       );
     } else {
       omniCommand(
@@ -68,6 +70,7 @@ export default async function RandomWallpaper() {
         preferences.toggleVicinaeSetting,
         colorGen,
         postProduction,
+        postScriptPath,
       );
     }
 


### PR DESCRIPTION
Script is provided by user in the setting as optional feature.
Useful for custom workflow ( for example :  color generation like `matugen`, or `lockscreen` like `hyprlock` , ... )
trying to match the post script feature of `Waypaper` 

*Unfortunately I have some issues about running dev  extension with  my vicinae installation.* 