### PR TITLE
feat (firefox): expose profile dir setting

### DIFF
--- a/extensions/firefox/package.json
+++ b/extensions/firefox/package.json
@@ -29,6 +29,16 @@
     "simple-plist": "^1.3.1",
     "sql.js": "^1.13.0"
   },
+  "preferences": [
+    {
+      "name": "profile_dir",
+      "required": false,
+      "type": "textfield",
+      "description": "Location from HOME of profiles for Firefox-based",
+      "default": ".mozilla/firefox/",
+      "title": "Profile Directory"
+    }
+  ],
   "scripts": {
     "build": "vici build",
     "dev": "vici develop",

--- a/extensions/firefox/src/utils.tsx
+++ b/extensions/firefox/src/utils.tsx
@@ -3,13 +3,13 @@ import { homedir } from "os";
 import path from "path";
 import { promisify } from "util";
 
-import { Action, ActionPanel, showToast, Toast } from "@vicinae/api";
+import { Action, ActionPanel, getPreferenceValues, showToast, Toast } from "@vicinae/api";
 import ini from "ini";
 import initSqlJs, { Database } from "sql.js";
 
 export const read = promisify(readFile);
 
-export const FIREFOX_FOLDER = path.join(homedir(), ".mozilla", "firefox");
+export const FIREFOX_FOLDER = path.join(homedir(), getPreferenceValues().profile_dir);
 
 export type Profile = { name: string; path: string };
 


### PR DESCRIPTION
Adds a setting to firefox extension to change the profiles directory

<img width="394" height="448" alt="image" src="https://github.com/user-attachments/assets/0ae9a3b0-3267-49b8-bfdf-6bea3103c586" />

closes #14 