### PR TITLE
feat(it-tools): properly tint tool icons

### DIFF
--- a/extensions/it-tools/src/it-tools-command.tsx
+++ b/extensions/it-tools/src/it-tools-command.tsx
@@ -9,6 +9,8 @@ import {
 	closeMainWindow,
 	PopToRootType,
 	getPreferenceValues,
+	ImageLike,
+	Color,
 } from "@vicinae/api";
 import toolsData from "./tools-data.json";
 import type { ITTool, PreferenceValues } from "./types";
@@ -19,14 +21,10 @@ const EXTENSION_ICON = "extension_icon.png";
 /**
  * Gets the icon for a tool, validating that it's a valid data URI
  */
-function getToolIcon(tool: ITTool): string {
-	if (!tool.icon) {
-		return EXTENSION_ICON;
-	}
-
+function getToolIcon(tool: ITTool): ImageLike {
 	// Validate that the icon is a valid data URI for SVG
-	if (tool.icon.startsWith("data:image/svg+xml")) {
-		return tool.icon;
+	if (tool.icon?.startsWith("data:image/svg+xml")) {
+		return { source: tool.icon, tintColor: Color.PrimaryText };
 	}
 
 	// If it's not a valid SVG data URI, fallback to default icon


### PR DESCRIPTION
@nikbpetrov vicinae supports tinting icons, which works especially well with svgs.
I tinted them of the color of the primary text so that tool icons can fit the theme in use.

<img width="788" height="496" alt="image" src="https://github.com/user-attachments/assets/cccd27dc-c1bd-4500-8744-29dbcdaca22a" />
