### PR TITLE
add available on to nixpkgs pr detail view

### DIFF
--- a/extensions/nix/src/api.ts
+++ b/extensions/nix/src/api.ts
@@ -379,5 +379,12 @@ export async function getNixpkgsPullRequest(number: number): Promise<GitHubPullR
   if (!res.ok) throw new Error(`GitHub ${res.status}`);
   const data: GitHubPullRequest = await res.json();
 
+  const res_status = await fetch(`https://nixpkgs.molybdenum.software/api/v2/landings/${number}`);
+  if (!res_status.ok) throw new Error(`PR Status ${res_status.status}`);
+
+  const statusData = await res_status.json();
+  data.availableOn = statusData.branches;
+
   return data;
 }
+

--- a/extensions/nix/src/components.tsx
+++ b/extensions/nix/src/components.tsx
@@ -458,6 +458,13 @@ export function PullRequestDetail({ pr }: { pr: GitHubPullRequest }) {
             text={pr.state === "open" ? "Open" : pr.merged_at ? "Merged" : "Closed"}
             icon={statusIcon}
           />
+          {pr.availableOn.length > 0 ? (
+            <Detail.Metadata.TagList title="Available on">
+              {pr.availableOn.map((l: string) => (
+                <Detail.Metadata.TagList.Item text={l} color={Color.PrimaryText} />
+              ))}
+            </Detail.Metadata.TagList>
+          ) : null}
           {pr.labels.length > 0 ? (
             <Detail.Metadata.TagList title="Labels">
               {pr.labels.map((l: GitHubLabel) => (

--- a/extensions/nix/src/types.ts
+++ b/extensions/nix/src/types.ts
@@ -218,6 +218,7 @@ export interface GitHubPullRequest {
   merged_at: string | null;
   labels: GitHubLabel[];
   requested_reviewers: GitHubUser[];
+  availableOn: string[];
   head: {
     ref: string;
   } | null;


### PR DESCRIPTION
<img width="882" height="539" alt="image" src="https://github.com/user-attachments/assets/32a789b3-2306-4f2e-9379-b1f2d6aea3eb" />

Adds info about which branches the merged pr is available on

Uses the api which was announced here
https://discourse.nixos.org/t/molybdenum-software-nixpkgs-pr-tracker-http-api/72910