### PR TITLE
fix(Omarchy Menu): change terminal app-id to com.omarchy.terminal to match original omarchy menu

### DIFF
--- a/extensions/omarchy-menu/src/helpers/actions.ts
+++ b/extensions/omarchy-menu/src/helpers/actions.ts
@@ -1,5 +1,5 @@
 export const terminal = (command: string) =>
-  `xdg-terminal-exec --app-id=com.omarchy.Omarchy ${command}`;
+  `xdg-terminal-exec --app-id=com.omarchy.terminal ${command}`;
 
 export const open_in_editor = (file: string) =>
   `notify-send "Editing config file" "${file}" && omarchy-launch-editor ${file}`;


### PR DESCRIPTION
When launching the AUR or package install terminal from the Walker menu, the window opens in floating mode. However, launching the same terminal from the Vicinea menu opens it in tiling mode.

This behavior is caused by a mismatch in the --app-id used when spawning the terminal.

Relevant code:
https://github.com/basecamp/omarchy/blob/master/bin/omarchy-menu