### PR TITLE
fix(hypr-keybinds): use hyprctl for keybinds instead of config file

### DIFF
--- a/extensions/hypr-keybinds/README.md
+++ b/extensions/hypr-keybinds/README.md
@@ -8,7 +8,7 @@ Look at what your binds are in a hyprland config file.
 
 ## Features
 
-- Display your keybinds from a single config file in a list with sweet detail!
+- Display all of your keybinds in a list with sweet detail!
 
 ## Requirements
 
@@ -19,11 +19,6 @@ Look at what your binds are in a hyprland config file.
 
 - `Show Hyprland Keybinds` — List your hyprland keybinds.
 
-## Extension Preferences
-
-<img src="assets/settings.png" alt="Settings" width="500" />
-
-- `Keybinds Config Path` — The path to your hyprland keybinds config file.
 
 ## Commments
 

--- a/extensions/hypr-keybinds/package-lock.json
+++ b/extensions/hypr-keybinds/package-lock.json
@@ -7,7 +7,7 @@
       "name": "hypr-keybinds",
       "license": "MIT",
       "dependencies": {
-        "@vicinae/api": "^0.13.4"
+        "@vicinae/api": "^0.17.3"
       },
       "devDependencies": {
         "typescript": "^5.9.2"
@@ -527,9 +527,9 @@
       }
     },
     "node_modules/@vicinae/api": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.13.4.tgz",
-      "integrity": "sha512-2HokH8gq3f1KSENXQPKX3TFFfkdfAV3gdZn8hDiKzPMGkRJvywSgpx5fkPPREJyb8EMs5nCYztytnqn9OelQXA==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.17.3.tgz",
+      "integrity": "sha512-yzm1eHhY04/zCMpLjSunIqbPlwcUH1V5DyoMPzAzJWXiZ3HkbNRGx2SYlFqpaeHZUj2QFEwQQSOiHcugyQkaDQ==",
       "license": "ISC",
       "dependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
@@ -538,7 +538,6 @@
         "@oclif/plugin-plugins": "^5",
         "@types/node": ">=18",
         "@types/react": "19.0.10",
-        "chalk": "^5.6.0",
         "chokidar": "^4.0.3",
         "esbuild": "^0.25.2",
         "react": "19.0.0",
@@ -619,18 +618,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -743,6 +730,7 @@
       "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3242,6 +3230,7 @@
       "version": "4.0.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3504,6 +3493,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3628,6 +3618,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/hypr-keybinds/package.json
+++ b/extensions/hypr-keybinds/package.json
@@ -18,21 +18,12 @@
       "mode": "view"
     }
   ],
-  "preferences": [
-    {
-      "name": "keybindsConfigPath",
-      "title": "Keybinds Config Path",
-      "description": "The path to your hyprland keybinds config file",
-      "required": true,
-      "type": "textfield"
-    }
-  ],
   "scripts": {
     "build": "vici build",
     "dev": "vici develop"
   },
   "dependencies": {
-    "@vicinae/api": "^0.13.4"
+    "@vicinae/api": "^0.17.3"
   },
   "devDependencies": {
     "typescript": "^5.9.2"


### PR DESCRIPTION
This PR changes the keybinding loading mechanism from using a user-defined file to querying hyprctl for all active keybindings.

This makes it so users no longer need to configure or maintain a separate keybindings file.