### PR TITLE
fix: correct terminal app-id in menu actions from com.omarchy.terminal to org.omarchy.terminal

### DIFF
--- a/extensions/omarchy-menu/src/helpers/actions.ts
+++ b/extensions/omarchy-menu/src/helpers/actions.ts
@@ -1,5 +1,5 @@
 export const terminal = (command: string) =>
-  `xdg-terminal-exec --app-id=com.omarchy.terminal ${command}`;
+  `xdg-terminal-exec --app-id=org.omarchy.terminal ${command}`;
 
 export const open_in_editor = (file: string) =>
   `notify-send "Editing config file" "${file}" && omarchy-launch-editor ${file}`;


### PR DESCRIPTION
Somehow manged to not get the change from "com" to "org" into the last PR