### PR TITLE
feat(pass): add copy or paste preference

### DIFF
--- a/extensions/pass/package.json
+++ b/extensions/pass/package.json
@@ -61,6 +61,24 @@
       "description": "How long to pin the last-used entry to the top of the list",
       "default": "120",
       "required": true
+    },
+    {
+      "name": "action",
+      "type": "dropdown",
+      "title": "Default Action",
+      "description": "Action to perform when pressing Enter on an entry",
+      "required": true,
+      "default": "paste",
+      "data": [
+        {
+          "title": "paste",
+          "value": "paste"
+        },
+        {
+          "title": "copy",
+          "value": "copy"
+        }
+      ]
     }
   ],
   "scripts": {

--- a/extensions/pass/src/pass.tsx
+++ b/extensions/pass/src/pass.tsx
@@ -74,7 +74,7 @@ export default function Command() {
                 <Action.Push
                   title="View Secrets"
                   icon={Icon.Key}
-                  target={<PasswordOptionsView password={entry.value} showOtpFirst={entry.showOtpFirst} />}
+                  target={<PasswordOptionsView password={entry.value} showOtpFirst={entry.showOtpFirst} action={preferences.action} />}
                 />
                 <Action title="Reload" icon={Icon.RotateAntiClockwise} onAction={refresh} />
               </ActionPanel>
@@ -85,7 +85,15 @@ export default function Command() {
     </List>
   );
 
-  function PasswordOptionsView({ password, showOtpFirst }: { password: string; showOtpFirst?: boolean }) {
+  function PasswordOptionsView({
+    password,
+    showOtpFirst,
+    action,
+  }: {
+    password: string;
+    showOtpFirst?: boolean;
+    action: "paste" | "copy";
+  }) {
     const [isLoading, setIsLoading] = useState(true);
     const [options, setOptions] = useState<PasswordOption[]>([]);
     const [error, setError] = useState<string | undefined>();
@@ -139,27 +147,35 @@ export default function Command() {
         ) : options.length === 0 ? (
           <List.EmptyView title="No fields found" description="The decrypted file is empty." />
         ) : (
-          options.map((option, index) => (
-            <List.Item
-              key={`${option.title}-${index}`}
-              title={option.title}
-              icon={getOptionIcon(option.title)}
-              actions={
-                <ActionPanel>
-                  <Action
-                    title="Paste"
-                    icon={Icon.Keyboard}
-                    onAction={() => performPasswordAction(password, option, "paste")}
-                  />
-                  <Action
-                    title="Copy to Clipboard"
-                    icon={Icon.CopyClipboard}
-                    onAction={() => performPasswordAction(password, option, "copy")}
-                  />
-                </ActionPanel>
-              }
-            />
-          ))
+          options.map((option, index) => {
+            const handleAction = () =>
+              performPasswordAction(password, option, action);
+            return (
+              <List.Item
+                key={`${option.title}-${index}`}
+                title={option.title}
+                icon={getOptionIcon(option.title)}
+                actions={
+                  <ActionPanel>
+                    <Action
+                      title={action === "paste" ? "Paste" : "Copy to Clipboard"}
+                      icon={
+                        action === "paste" ? Icon.Keyboard : Icon.CopyClipboard
+                      }
+                      onAction={handleAction}
+                    />
+                    <Action
+                      title={action === "copy" ? "Copy to Clipboard" : "Paste"}
+                      icon={
+                        action === "copy" ? Icon.CopyClipboard : Icon.Keyboard
+                      }
+                      onAction={handleAction}
+                    />
+                  </ActionPanel>
+                }
+              />
+            );
+          })
         )}
       </List>
     );

--- a/extensions/pass/src/preferences.ts
+++ b/extensions/pass/src/preferences.ts
@@ -7,6 +7,7 @@ type RawPreferences = {
   additionalPath?: string;
   otpAfterPassword?: boolean;
   lastUsedTtl?: string;
+  action?: "paste" | "copy";
 };
 
 export type Preferences = {
@@ -15,6 +16,7 @@ export type Preferences = {
   additionalPath?: string;
   otpAfterPassword: boolean;
   lastUsedTtlSeconds: number;
+  action: "paste" | "copy";
 };
 
 export function getPreferences(): Preferences {
@@ -26,6 +28,7 @@ export function getPreferences(): Preferences {
     additionalPath: sanitizeString(raw.additionalPath),
     otpAfterPassword: raw.otpAfterPassword ?? true,
     lastUsedTtlSeconds: parsePositiveInt(raw.lastUsedTtl, 120),
+    action: raw.action || "paste",
   };
 }
 

--- a/extensions/pass/src/utils/actions.ts
+++ b/extensions/pass/src/utils/actions.ts
@@ -7,13 +7,14 @@ export type PasswordActionType = "copy" | "paste";
 export async function performPasswordAction(
   passwordName: string,
   option: PasswordOption,
-  action: PasswordActionType,
+  action: PasswordActionType
 ): Promise<void> {
   const concealed = option.type === "password" || option.type === "otp";
 
   try {
     if (action === "copy") {
       await Clipboard.copy(option.value, { concealed });
+      await closeMainWindow();
     } else {
       await closeMainWindow();
       await Clipboard.paste(option.value);


### PR DESCRIPTION
This PR adds a new preference option to the pass extension that allows users to set the default action to “Copy to clipboard.” It also updates the behavior so that copying automatically closes the window.