### PR TITLE
fix(hypr-keybinds): include kb.arg and kb.description in filtering

### DIFF
--- a/extensions/hypr-keybinds/src/hyprland-keybinds.tsx
+++ b/extensions/hypr-keybinds/src/hyprland-keybinds.tsx
@@ -47,7 +47,6 @@ export default function Command() {
       />
     );
   }
-  console.log(keybinds);
   return (
     <List
       isLoading={isLoading}
@@ -74,6 +73,7 @@ export default function Command() {
               key={`${kb.key}-${kb.dispatcher}-${idx}`}
               title={title}
               accessories={accessories}
+              keywords={[title, kb.description, kb.arg]}
               icon={Icon.Keyboard}
               actions={
                 <ActionPanel>


### PR DESCRIPTION
This PR adds the keyboard shortcut description and arguments to the searchable keywords, making the hotkey’s launch command searchable as well.