### PR TITLE
feat(pulseaudio): add playback stream support

### DIFF
--- a/extensions/pulseaudio/package-lock.json
+++ b/extensions/pulseaudio/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "sound-manager",
+  "name": "pulseaudio",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sound-manager",
+      "name": "pulseaudio",
       "license": "MIT",
       "dependencies": {
-        "@vicinae/api": "^0.17.0"
+        "@vicinae/api": "^0.18.1"
       },
       "devDependencies": {
         "typescript": "^5.9.2"
@@ -527,9 +527,9 @@
       }
     },
     "node_modules/@vicinae/api": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.17.0.tgz",
-      "integrity": "sha512-6TgopOJyEywDbXezA1X4WCIMIQznbM+FWOJzD3OrVZ4/POQUlvDM9d3THbhi/Uo6NAgdyOcPCv5tjC5S7bT4FQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.18.1.tgz",
+      "integrity": "sha512-gVa/Lghv1M1ITEzpCRNO8UFanabNx8WL7regV9KtnHQQfUbm60PZBiPIRhhTjDc62lsMgWgJm+dloBHwY8Rx5A==",
       "license": "ISC",
       "dependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
@@ -730,6 +730,7 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3229,6 +3230,7 @@
       "version": "4.0.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3491,6 +3493,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3615,6 +3618,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/pulseaudio/package.json
+++ b/extensions/pulseaudio/package.json
@@ -24,7 +24,7 @@
     "dev": "vici develop"
   },
   "dependencies": {
-    "@vicinae/api": "^0.17.0"
+    "@vicinae/api": "^0.18.1"
   },
   "devDependencies": {
     "typescript": "^5.9.2"

--- a/extensions/pulseaudio/src/components/AudioDeviceItem.tsx
+++ b/extensions/pulseaudio/src/components/AudioDeviceItem.tsx
@@ -121,8 +121,6 @@ export function AudioDeviceItem(props: {
 
   return (
     <List.Item
-      key={device.name}
-      id={`${kind}:${device.name}`}
       title={title}
       subtitle={subtitle}
       icon={icon}

--- a/extensions/pulseaudio/src/components/PlaybackDetail.tsx
+++ b/extensions/pulseaudio/src/components/PlaybackDetail.tsx
@@ -1,0 +1,64 @@
+import { Color, Icon, List } from "@vicinae/api";
+import { appNameForStream, type PactlSinkInput } from "../pactl";
+import { speakerIconForPercentAndMute } from "../ui/audioIcons";
+import { prettyValue } from "../ui/format";
+
+export function PlaybackDetail(props: {
+  sinkInput: PactlSinkInput;
+  volumePercent?: number;
+  sinkName?: string;
+}) {
+  const { sinkInput, volumePercent, sinkName } = props;
+
+  const propsMap = sinkInput.properties ?? {};
+  const importantKeys = [
+    "application.name",
+    "application.process.binary",
+    "media.name",
+  ].filter((k) => !!propsMap[k]);
+
+  const title = appNameForStream(sinkInput);
+
+  return (
+    <List.Item.Detail
+      markdown={`# ${title}`}
+      metadata={
+        <List.Item.Detail.Metadata>
+          <List.Item.Detail.Metadata.Label
+            title="Status"
+            icon={speakerIconForPercentAndMute(volumePercent, sinkInput.mute)}
+            text={`${sinkInput.mute ? "Muted" : "Unmuted"}${
+              typeof volumePercent === "number" ? ` · ${volumePercent}%` : ""
+            }`}
+          />
+          <List.Item.Detail.Metadata.Separator />
+          <List.Item.Detail.Metadata.TagList title="Quick tags">
+            <List.Item.Detail.Metadata.TagList.Item
+              color={sinkInput.mute ? Color.Red : Color.SecondaryText}
+              icon={sinkInput.mute ? Icon.SpeakerOff : Icon.SpeakerOn}
+              text={sinkInput.mute ? "Muted" : "Unmuted"}
+            />
+          </List.Item.Detail.Metadata.TagList>
+          {sinkName ? (
+            <List.Item.Detail.Metadata.Label
+              title="Output Device"
+              text={sinkName}
+            />
+          ) : null}
+          {importantKeys.length ? (
+            <>
+              <List.Item.Detail.Metadata.Separator />
+              {importantKeys.map((k) => (
+                <List.Item.Detail.Metadata.Label
+                  key={k}
+                  title={k}
+                  text={prettyValue(propsMap[k])}
+                />
+              ))}
+            </>
+          ) : null}
+        </List.Item.Detail.Metadata>
+      }
+    />
+  );
+}

--- a/extensions/pulseaudio/src/components/SinkInputItem.tsx
+++ b/extensions/pulseaudio/src/components/SinkInputItem.tsx
@@ -1,0 +1,116 @@
+import { Action, ActionPanel, Icon, Keyboard, List } from "@vicinae/api";
+import {
+  appNameForStream,
+  pactl,
+  percentFromVolume,
+  type PactlSinkInput,
+} from "../pactl";
+import { PlaybackDetail } from "./PlaybackDetail";
+import { SetVolumeForm } from "./SetVolumeForm";
+import { speakerIconForPercentAndMute } from "../ui/audioIcons";
+import { deviceAccessories } from "../ui/deviceAccessories";
+import { clamp } from "../ui/format";
+import { showErrorToast } from "../ui/toasts";
+
+export function SinkInputItem(props: {
+  sinkInput: PactlSinkInput;
+  refresh: () => Promise<void>;
+  refreshShortcut: Keyboard.Shortcut | Keyboard.Shortcut.Common;
+  sinkName?: string;
+}) {
+  const { sinkInput, refresh, refreshShortcut, sinkName } = props;
+
+  const vol = percentFromVolume(sinkInput.volume);
+  const icon = speakerIconForPercentAndMute(vol, sinkInput.mute);
+  const title = appNameForStream(sinkInput);
+
+  async function toggleMute(): Promise<void> {
+    try {
+      await pactl.setSinkInputMute(sinkInput.index, "toggle");
+      await refresh();
+    } catch (e) {
+      await showErrorToast({ title: "Failed to toggle mute", error: e });
+    }
+  }
+
+  async function setVolume(next: number): Promise<void> {
+    try {
+      const safe = clamp(next, 0, 150);
+      await pactl.setSinkInputVolume(sinkInput.index, safe);
+      await refresh();
+    } catch (e) {
+      await showErrorToast({ title: "Failed to change volume", error: e });
+    }
+  }
+
+  const actions = (
+    <ActionPanel title={title}>
+      <ActionPanel.Section title="Stream">
+        <Action
+          title={sinkInput.mute ? "Unmute Stream" : "Mute Stream"}
+          icon={sinkInput.mute ? Icon.SpeakerOn : Icon.SpeakerOff}
+          onAction={toggleMute}
+        />
+        <Action.CopyToClipboard title="Copy Stream Name" content={title} />
+      </ActionPanel.Section>
+      <ActionPanel.Section title="Volume">
+        <Action
+          title="Increase Volume (+5%)"
+          icon={Icon.SpeakerUp}
+          onAction={() => setVolume((vol ?? 0) + 5)}
+        />
+        <Action
+          title="Decrease Volume (-5%)"
+          icon={Icon.SpeakerDown}
+          onAction={() => setVolume((vol ?? 0) - 5)}
+        />
+        <Action.Push
+          title="Set Volume…"
+          icon={Icon.Gauge}
+          target={
+            <SetVolumeForm
+              kind="sink-input"
+              deviceIndex={sinkInput.index}
+              deviceTitle={title}
+              currentPercent={vol}
+              onDone={refresh}
+            />
+          }
+        />
+      </ActionPanel.Section>
+      <ActionPanel.Section title="Other">
+        <Action
+          title="Refresh"
+          icon={Icon.ArrowClockwise}
+          shortcut={refreshShortcut}
+          onAction={refresh}
+        />
+      </ActionPanel.Section>
+    </ActionPanel>
+  );
+
+  return (
+    <List.Item
+      title={title}
+      icon={icon}
+      accessories={deviceAccessories({
+        isDefault: false,
+        muted: sinkInput.mute,
+        volumePercent: vol,
+      })}
+      detail={
+        <PlaybackDetail
+          sinkInput={sinkInput}
+          volumePercent={vol}
+          sinkName={sinkName}
+        />
+      }
+      actions={actions}
+      keywords={[
+        sinkInput.name,
+        sinkName ?? "",
+        sinkInput.properties?.["application.name"] ?? "",
+      ]}
+    />
+  );
+}

--- a/extensions/pulseaudio/src/pactl.ts
+++ b/extensions/pulseaudio/src/pactl.ts
@@ -131,11 +131,25 @@ function toDevice(v: unknown): PactlDevice | undefined {
 }
 
 function toSinkInput(v: unknown): PactlSinkInput | undefined {
-  const base = toDevice(v);
-  if (!base || !isObject(v)) return undefined;
+  if (!isObject(v)) return undefined;
+  const index = typeof v.index === "number" ? v.index : undefined;
+  const props = toStringRecord(v.properties);
+  const name = props?.["application.name"];
+  const mute = typeof v.mute === "boolean" ? v.mute : undefined;
   const sink = typeof v.sink === "number" ? v.sink : undefined;
   const driver = typeof v.driver === "string" ? v.driver : undefined;
-  return { ...base, sink, driver };
+  if (index === undefined || name === undefined || mute === undefined)
+    return undefined;
+  return {
+    index,
+    name,
+    mute,
+    description: typeof v.description === "string" ? v.description : undefined,
+    volume: toVolumeRecord(v.volume),
+    properties: props,
+    sink,
+    driver,
+  };
 }
 
 function toSourceOutput(v: unknown): PactlSourceOutput | undefined {
@@ -412,10 +426,6 @@ export function appNameForStream(d: PactlDevice): string {
 
 export function isAudioSource(d: PactlDevice): boolean {
   return d.properties?.["media.class"] === "Audio/Source";
-}
-
-export function isAudioSink(d: PactlDevice): boolean {
-  return d.properties?.["media.class"] === "Audio/Sink";
 }
 
 // Backwards-compatible function exports (internal calls go through the singleton client).


### PR DESCRIPTION
Adds support for viewing and controlling active playback streams. You can now see which apps are playing audio and manage them individually mute, adjust volume, or set a custom level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Playback view to monitor active audio streams with detailed stream info and metadata.
  * Per-stream controls: mute toggle, +/- volume steps, precise volume editor, and copy-stream-name action.
  * Quick tags show Muted/Unmuted and optional output device; playback entries support shortcut-triggered refresh.
  * View filter now includes a Playback option to show only active streams.

* **Chores**
  * Updated dependency @vicinae/api to ^0.18.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->