### PR TITLE
feat(pulseaudio): allow user to toggle detail view

### DIFF
--- a/extensions/pulseaudio/src/components/AudioDeviceItem.tsx
+++ b/extensions/pulseaudio/src/components/AudioDeviceItem.tsx
@@ -6,15 +6,17 @@ import { micIconForMute, speakerIconForPercentAndMute } from "../ui/audioIcons";
 import { deviceAccessories } from "../ui/deviceAccessories";
 import { clamp } from "../ui/format";
 import { showErrorToast } from "../ui/toasts";
+import { detailsShortcut } from "../shortcuts";
 
 export function AudioDeviceItem(props: {
   kind: "sink" | "source";
   device: PactlDevice;
   defaultName?: string;
   refresh: () => Promise<void>;
+  toggleDetail: () => void;
   refreshShortcut: Keyboard.Shortcut | Keyboard.Shortcut.Common;
 }) {
-  const { kind, device, defaultName, refresh, refreshShortcut } = props;
+  const { kind, device, defaultName, refresh, refreshShortcut, toggleDetail } = props;
 
   const isDefault = !!defaultName && device.name === defaultName;
   const vol = percentFromVolume(device.volume);
@@ -95,6 +97,12 @@ export function AudioDeviceItem(props: {
           onAction={toggleMute}
         />
         <Action.CopyToClipboard title="Copy Device Name" content={device.name} />
+        <Action
+          shortcut={detailsShortcut}
+          title="Toggle Details"
+          icon={Icon.Eye}
+          onAction={toggleDetail}
+        />
       </ActionPanel.Section>
       <ActionPanel.Section title="Volume">
         <Action title="Increase Volume (+5%)" icon={Icon.SpeakerUp} onAction={() => setVolume((vol ?? 0) + 5)} />

--- a/extensions/pulseaudio/src/components/SinkInputItem.tsx
+++ b/extensions/pulseaudio/src/components/SinkInputItem.tsx
@@ -11,14 +11,16 @@ import { speakerIconForPercentAndMute } from "../ui/audioIcons";
 import { deviceAccessories } from "../ui/deviceAccessories";
 import { clamp } from "../ui/format";
 import { showErrorToast } from "../ui/toasts";
+import { detailsShortcut } from "../shortcuts";
 
 export function SinkInputItem(props: {
+  toggleDetail: () => void;
   sinkInput: PactlSinkInput;
   refresh: () => Promise<void>;
   refreshShortcut: Keyboard.Shortcut | Keyboard.Shortcut.Common;
   sinkName?: string;
 }) {
-  const { sinkInput, refresh, refreshShortcut, sinkName } = props;
+  const { sinkInput, refresh, refreshShortcut, sinkName, toggleDetail } = props;
 
   const vol = percentFromVolume(sinkInput.volume);
   const icon = speakerIconForPercentAndMute(vol, sinkInput.mute);
@@ -52,6 +54,12 @@ export function SinkInputItem(props: {
           onAction={toggleMute}
         />
         <Action.CopyToClipboard title="Copy Stream Name" content={title} />
+        <Action
+          shortcut={detailsShortcut}
+          title="Toggle Details"
+          icon={Icon.Eye}
+          onAction={toggleDetail}
+        />
       </ActionPanel.Section>
       <ActionPanel.Section title="Volume">
         <Action

--- a/extensions/pulseaudio/src/pulseaudio.tsx
+++ b/extensions/pulseaudio/src/pulseaudio.tsx
@@ -16,9 +16,12 @@ type ViewFilter = "all" | "outputs" | "inputs" | "playback";
 
 export default function SoundManagerCommand() {
   const { audio, isLoading, refresh } = useAudioState();
+  const [showDetail, setShowDetail] = useState(false);
   const [viewFilter, setViewFilter] = useState<ViewFilter>("all");
   const refreshShortcut = Keyboard.Shortcut.Common.Refresh as Keyboard.Shortcut.Common;
 
+  const handleToggleDetail = () => setShowDetail((prev) => !prev);
+  
   const searchAccessory = useMemo(
     () => (
       <List.Dropdown
@@ -84,7 +87,7 @@ export default function SoundManagerCommand() {
   return (
     <List
       isLoading={isLoading}
-      isShowingDetail
+      isShowingDetail={showDetail}
       navigationTitle="Sound Settings"
       searchBarPlaceholder="Search audio devices…"
       searchBarAccessory={searchAccessory}
@@ -118,6 +121,7 @@ export default function SoundManagerCommand() {
           {audio.sinkInputs.map((sinkInput) => {
             const sinkName = audio.sinks.find((s) => s.index === sinkInput.sink)?.description;
             return <SinkInputItem
+              toggleDetail={handleToggleDetail}
               key={sinkInput.index}
               sinkInput={sinkInput}
               refresh={refresh}
@@ -141,6 +145,7 @@ export default function SoundManagerCommand() {
           {sinksSorted.map((sink) => (
             <AudioDeviceItem
               key={sink.name}
+              toggleDetail={handleToggleDetail}
               kind="sink"
               device={sink}
               defaultName={audio?.info.default_sink_name}
@@ -164,6 +169,7 @@ export default function SoundManagerCommand() {
         >
           {sourcesSorted.map((source) => (
             <AudioDeviceItem
+              toggleDetail={handleToggleDetail}
               key={source.name}
               kind="source"
               device={source}

--- a/extensions/pulseaudio/src/shortcuts.ts
+++ b/extensions/pulseaudio/src/shortcuts.ts
@@ -1,0 +1,6 @@
+import { Keyboard } from "@vicinae/api/dist";
+
+export const detailsShortcut: Keyboard.Shortcut = {
+  modifiers: ["shift"],
+  key: "i",
+};


### PR DESCRIPTION
This PR adds the ability for users to toggle the detail view and changes its default state to closed.

The reasoning behind this change is that the full-width list view typically provides the information users need most of the time. By defaulting the detail view to closed, the list view can make better use of the available screen space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Shift+I keyboard shortcut to toggle detail panel visibility for audio devices and applications
  * Improved audio device management with new detail toggle capability
  * Enhanced application items with detail visibility controls for better information access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->