### PR TITLE
feat(pulseaudio): allow user to select output source for playback item

### DIFF
--- a/extensions/pulseaudio/src/components/SelectOutputSink.tsx
+++ b/extensions/pulseaudio/src/components/SelectOutputSink.tsx
@@ -1,0 +1,71 @@
+import { Action, ActionPanel, Icon, List, useNavigation } from "@vicinae/api";
+import {
+  displayNameForDevice,
+  pactl,
+  type PactlSink,
+  type PactlSinkInput,
+} from "../pactl";
+import { useAudioState } from "../hooks/useAudioState";
+import { showErrorToast } from "../ui/toasts";
+
+export function SelectOutputSink(props: {
+  sinkInput: PactlSinkInput;
+  onOutputChange: () => Promise<void>;
+}) {
+  const { sinkInput, onOutputChange } = props;
+  const { audio, isLoading } = useAudioState();
+  const { pop } = useNavigation();
+  const sinks = audio?.sinks ?? [];
+
+  async function selectSink(sink: PactlSink) {
+    try {
+      await pactl.moveSinkInputToSink(sinkInput.index, sink.name);
+      await onOutputChange();
+      pop();
+    } catch (e) {
+      await showErrorToast({ title: "Failed to move stream", error: e });
+    }
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      navigationTitle="Select Output Device"
+      searchBarPlaceholder="Search output devices…"
+    >
+      {sinks.map((sink) => {
+        const title = displayNameForDevice(sink);
+        const isCurrent = sink.index === sinkInput.sink;
+        return (
+          <List.Item
+            key={sink.name}
+            title={title}
+            icon={Icon.SpeakerHigh}
+            accessories={
+              isCurrent
+                ? [
+                    {
+                      icon: Icon.Checkmark,
+                      tag: {
+                        color: "green",
+                        value: "Current",
+                      },
+                    },
+                  ]
+                : []
+            }
+            actions={
+              <ActionPanel>
+                <Action
+                  title="Select Output"
+                  icon={Icon.SpeakerHigh}
+                  onAction={() => selectSink(sink)}
+                />
+              </ActionPanel>
+            }
+          />
+        );
+      })}
+    </List>
+  );
+}

--- a/extensions/pulseaudio/src/components/SinkInputItem.tsx
+++ b/extensions/pulseaudio/src/components/SinkInputItem.tsx
@@ -6,6 +6,7 @@ import {
   type PactlSinkInput,
 } from "../pactl";
 import { PlaybackDetail } from "./PlaybackDetail";
+import { SelectOutputSink } from "./SelectOutputSink";
 import { SetVolumeForm } from "./SetVolumeForm";
 import { speakerIconForPercentAndMute } from "../ui/audioIcons";
 import { deviceAccessories } from "../ui/deviceAccessories";
@@ -45,6 +46,13 @@ export function SinkInputItem(props: {
 
   const actions = (
     <ActionPanel title={title}>
+      <ActionPanel.Section title="Output">
+        <Action.Push
+          title="Select Output Device"
+          icon={Icon.SpeakerHigh}
+          target={<SelectOutputSink sinkInput={sinkInput} onOutputChange={refresh} />}
+        />
+      </ActionPanel.Section>
       <ActionPanel.Section title="Stream">
         <Action
           title={sinkInput.mute ? "Unmute Stream" : "Mute Stream"}


### PR DESCRIPTION
This PR adds support for changing the output source associated with a playback item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to select and change audio output devices.
  * Searchable list of available output sinks with loading state and search placeholder.
  * "Select Output Device" action on sink items opens the selection UI.
  * Current output is marked with a "Current" badge; selections surface success/errors via toast.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->