### PR TITLE
feat(vscode-recents): Always show machine ip for remote-ssh

### DIFF
--- a/extensions/vscode-recents/src/components/ProjectListItem.tsx
+++ b/extensions/vscode-recents/src/components/ProjectListItem.tsx
@@ -1,6 +1,6 @@
 import { List, Icon } from "@vicinae/api";
 import { ProjectActions } from "./ProjectActions";
-import { RecentProject, ProjectType } from "../types";
+import { RecentProject, ProjectType, ProjectEnvironment } from "../types";
 
 interface ProjectListItemProps {
     project: RecentProject;
@@ -35,9 +35,21 @@ function getProjectTypeLabel(type: ProjectType): List.Item.Tag {
 }
 
 export function ProjectListItem({ project, index, onRemove }: ProjectListItemProps) {
+    const hasExistingSSHInfo = /\[SSH:\s*[^\]]+\]/.test(project.label);
+    const hasExistingDevContainerInfo = /\[Dev Container\]/.test(project.label);
+
+    let title = project.label;
+    // VSCode already includes "tags" in the project label occasionally
+    // but it is extremely inconsistent, so we add them ourselves for clarity
+    if (project.environment === ProjectEnvironment.RemoteSSH && project.machineName && !hasExistingSSHInfo) {
+        title = `${project.label} [SSH: ${project.machineName}]`;
+    } else if (project.environment === ProjectEnvironment.DevContainer && !hasExistingDevContainerInfo) {
+        title = `${project.label} [Dev Container]`;
+    }
+
     return (
         <List.Item
-            title={project.label}
+            title={title}
             subtitle={project.path}
             icon={getProjectIcon(project.type)}
             key={`${project.path}-${index}`}

--- a/extensions/vscode-recents/src/types.ts
+++ b/extensions/vscode-recents/src/types.ts
@@ -1,10 +1,10 @@
 export enum ProjectEnvironment {
     Local = "",
-    Codespaces = "vsonline",
     RemoteWSL = "wsl",
+    Codespace = "vsonline",
+    RemoteTunnel = "tunnel",
     RemoteSSH = "ssh-remote",
     DevContainer = "dev-container",
-    RemoteTunnel = "tunnel",
 }
 
 export enum ProjectType {
@@ -16,9 +16,10 @@ export enum ProjectType {
 export interface RecentProject {
     path: string;
     label: string;
-    environment: ProjectEnvironment;
     type: ProjectType;
+    machineName?: string;
     lastOpened: number | undefined;
+    environment: ProjectEnvironment;
 }
 
 export interface VSCodeDatabaseEntry {

--- a/extensions/vscode-recents/src/util/projects.ts
+++ b/extensions/vscode-recents/src/util/projects.ts
@@ -23,7 +23,7 @@ function parseProjectEntry(entry: VSCodeDatabaseEntry): RecentProject | null {
         projectPath = decodeFileUri(entry.fileUri);
     }
 
-    const { environment } = parseRemoteAuthority(entry.remoteAuthority);
+    const { environment, machineName } = parseRemoteAuthority(entry.remoteAuthority);
 
     // Validate path based on environment (only check local paths exist)
     if (!validateProjectPath(projectPath, environment)) {
@@ -39,6 +39,7 @@ function parseProjectEntry(entry: VSCodeDatabaseEntry): RecentProject | null {
         path: projectPath,
         lastOpened: lastOpened,
         environment: environment,
+        machineName: machineName,
     };
 }
 


### PR DESCRIPTION
This PR fixes the issue with recent projects on remote machine sometimes not having `[SSH: machine_ip]` appended to it

Before
<img width="780" height="482" alt="image" src="https://github.com/user-attachments/assets/251d23a1-c0fb-4894-ad65-9ff293b3b3cb" />

After
<img width="778" height="492" alt="image" src="https://github.com/user-attachments/assets/a5348b9d-6b53-4314-9ced-cde54e43ce22" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Project list items now display enhanced environment information, automatically appending SSH machine names for remote connections and Dev Container tags for containerized development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->