### PR TITLE
fix(vscode-recents): NODE_ENV env getting set

### DIFF
--- a/extensions/vscode-recents/src/util/vscode.ts
+++ b/extensions/vscode-recents/src/util/vscode.ts
@@ -56,7 +56,8 @@ export async function openProjectInVSCode(project: RecentProject): Promise<void>
             command += ` --file-uri "${project.path}"`;
         }
 
-        await execAsync(`${command}`);
+        const { NODE_ENV, ...env } = process.env;
+        await execAsync(`${command}`, { env });
     } catch (error) {
         console.error(`Error opening project in ${vscodeFlavour}:`, error);
         showToast({


### PR DESCRIPTION
This PR fixes the issue that the NODE_ENV is getting set to production when opening a vscode project for the process.

The vscode-recents extension uses `execAsync` to run the command to open vscode but this pollutes the vscode process with the envs from vicinae. Most of the vicinae envs are not a problem but as a web dev the NODE_ENV getting set to production is quite annoying e.g. `npm install `won't install devDependencies.

To fix this issue this PR removes the NODE_ENV from the env getting passed to the vscode process.

I know this not the best way to do it but I didn't find a way to do this with the `open` or `openInTerminal`  functions from the vicinae API which don't set the env.

