### PR TITLE
feat(omarchy-menu): add support for showing all results in root omarchy search

### DIFF
--- a/extensions/omarchy-menu/package-lock.json
+++ b/extensions/omarchy-menu/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/utils": "^2.2.2",
-        "@vicinae/api": "^0.16.1"
+        "@vicinae/api": "^0.18.3"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
@@ -663,7 +663,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
       "integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -673,7 +672,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.0.tgz",
       "integrity": "sha512-5+Q3PKH35YsnoPTh75LucALdAxom6xh5D1oeY561x4cqBuH24ZFVyFREPe14xgnrtmGu3EEt1dIi60wRVSnGCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.1",
         "@inquirer/core": "^10.3.0",
@@ -698,7 +696,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.19.tgz",
       "integrity": "sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.0",
         "@inquirer/type": "^3.0.9"
@@ -720,7 +717,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
       "integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.1",
         "@inquirer/figures": "^1.0.14",
@@ -748,7 +744,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -763,7 +758,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.21.tgz",
       "integrity": "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.0",
         "@inquirer/external-editor": "^1.0.2",
@@ -786,7 +780,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.21.tgz",
       "integrity": "sha512-+mScLhIcbPFmuvU3tAGBed78XvYHSvCl6dBiYMlzCLhpr0bzGzd8tfivMMeqND6XZiaZ1tgusbUHJEfc6YzOdA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.0",
         "@inquirer/type": "^3.0.9",
@@ -809,7 +802,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
       "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chardet": "^2.1.0",
         "iconv-lite": "^0.7.0"
@@ -831,7 +823,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
       "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -841,7 +832,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.5.tgz",
       "integrity": "sha512-7GoWev7P6s7t0oJbenH0eQ0ThNdDJbEAEtVt9vsrYZ9FulIokvd823yLyhQlWHJPGce1wzP53ttfdCZmonMHyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.0",
         "@inquirer/type": "^3.0.9"
@@ -863,7 +853,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.21.tgz",
       "integrity": "sha512-5QWs0KGaNMlhbdhOSCFfKsW+/dcAVC2g4wT/z2MCiZM47uLgatC5N20kpkDQf7dHx+XFct/MJvvNGy6aYJn4Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.0",
         "@inquirer/type": "^3.0.9"
@@ -885,7 +874,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.21.tgz",
       "integrity": "sha512-xxeW1V5SbNFNig2pLfetsDb0svWlKuhmr7MPJZMYuDnCTkpVBI+X/doudg4pznc1/U+yYmWFFOi4hNvGgUo7EA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.1",
         "@inquirer/core": "^10.3.0",
@@ -908,7 +896,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.9.0.tgz",
       "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.0",
         "@inquirer/confirm": "^5.1.19",
@@ -938,7 +925,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.9.tgz",
       "integrity": "sha512-AWpxB7MuJrRiSfTKGJ7Y68imYt8P9N3Gaa7ySdkFj1iWjr6WfbGAhdZvw/UnhFXTHITJzxGUI9k8IX7akAEBCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.0",
         "@inquirer/type": "^3.0.9",
@@ -961,7 +947,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.0.tgz",
       "integrity": "sha512-a5SzB/qrXafDX1Z4AZW3CsVoiNxcIYCzYP7r9RzrfMpaLpB+yWi5U8BWagZyLmwR0pKbbL5umnGRd0RzGVI8bQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.0",
         "@inquirer/figures": "^1.0.14",
@@ -985,7 +970,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.0.tgz",
       "integrity": "sha512-kaC3FHsJZvVyIjYBs5Ih8y8Bj4P/QItQWrZW22WJax7zTN+ZPXVGuOM55vzbdCP9zKUiBd9iEJVdesujfF+cAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.1",
         "@inquirer/core": "^10.3.0",
@@ -1010,7 +994,6 @@
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
       "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1178,7 +1161,6 @@
       "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.39.tgz",
       "integrity": "sha512-OwAZNnSpuDjKyhAwoOJkFWxGswPFKBB4hpNIMsj6PUtbKwGBPmD+2wGGPgTsDioVwLmUELSb2bZ+1dxHfvXmvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oclif/core": "^4",
         "ansis": "^3.16.0",
@@ -1206,7 +1188,6 @@
       "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.72.tgz",
       "integrity": "sha512-CRcqHGdcEL4l5cls5F9FvwKt04LkdG7WyFozOu2vP1/3w34S29zbw8Tx1gAzfBZDDme5ChSaqFXU5qbTLx5yYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^7.9.0",
         "@oclif/core": "^4.8.0",
@@ -1222,7 +1203,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
       "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fastest-levenshtein": "^1.0.7"
       }
@@ -1278,7 +1258,6 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.103.6.tgz",
       "integrity": "sha512-x34deBLt8BNCIztMjsYPU8eGz4xFp444PJzxybIvDt86ZCk6phlTLD11qtkyZKOURFIoncebNDVTJn5KdO09nA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -1317,7 +1296,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1326,15 +1304,13 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@raycast/api/node_modules/@types/react": {
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1436,6 +1412,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1496,6 +1473,7 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -1709,9 +1687,9 @@
       }
     },
     "node_modules/@vicinae/api": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.16.2.tgz",
-      "integrity": "sha512-IOMKxIl6y5ZBJEU/GeLsh0b7/JDCtQisWvKS8o72bt12LQClLfurIKgqb2IbEfVy2QSEeC8uOkXkw9xYCpHo/Q==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.18.3.tgz",
+      "integrity": "sha512-pP0bUUVEYd3FBRWHiF0iB7ScgqsQDRpaGNycVI7w4mJoiQqdwqmrZn3hO+OS51Xxb6yVilhtdHV/cG2mdJS7dg==",
       "license": "ISC",
       "dependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
@@ -1720,7 +1698,6 @@
         "@oclif/plugin-plugins": "^5",
         "@types/node": ">=18",
         "@types/react": "19.0.10",
-        "chalk": "^5.6.0",
         "chokidar": "^4.0.3",
         "esbuild": "^0.25.2",
         "react": "19.0.0",
@@ -1743,24 +1720,13 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@vicinae/api/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1937,8 +1903,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -1987,7 +1952,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2115,6 +2079,7 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2168,6 +2133,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2388,7 +2354,6 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -2582,7 +2547,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
       "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2900,7 +2864,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -5198,6 +5161,7 @@
       "version": "4.0.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5531,6 +5495,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5554,6 +5519,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5675,8 +5641,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -5718,7 +5683,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -5894,6 +5858,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6061,7 +6026,6 @@
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },

--- a/extensions/omarchy-menu/package.json
+++ b/extensions/omarchy-menu/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@raycast/utils": "^2.2.2",
-    "@vicinae/api": "^0.16.1"
+    "@vicinae/api": "^0.18.3"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",

--- a/extensions/omarchy-menu/src/config/about.ts
+++ b/extensions/omarchy-menu/src/config/about.ts
@@ -4,6 +4,6 @@ import { MenuItem } from "./types";
 export const about: MenuItem = {
   id: "about",
   name: "About",
-  icon: Icon.Info,
+  icon: Icon.Info01,
   command: "omarchy-launch-about",
 };

--- a/extensions/omarchy-menu/src/config/install.ts
+++ b/extensions/omarchy-menu/src/config/install.ts
@@ -13,7 +13,7 @@ import { MenuItem } from "./types";
 export const installMenu: MenuItem = {
   id: "install",
   name: "Install",
-  icon: Icon.MemoryChip,
+  icon: Icon.PlusSquare,
   items: [
     {
       id: "package",

--- a/extensions/omarchy-menu/src/config/menu.ts
+++ b/extensions/omarchy-menu/src/config/menu.ts
@@ -7,8 +7,10 @@ import { remove } from "./remove";
 import { update } from "./update";
 import { about } from "./about";
 import { system } from "./system";
+import { MenuItem } from "./types";
 
 export { type MenuItem } from "./types";
+export type FlattenedMenuItem = MenuItem & { path: string };
 
 export const MENU_ITEMS = [
   learn,
@@ -21,3 +23,19 @@ export const MENU_ITEMS = [
   about,
   system,
 ];
+
+export const FLATTEND_MENU_ITEMS: FlattenedMenuItem[] = [];
+const flatten = (items: MenuItem[], path: string[] = []) => {
+  for (const item of items) {
+    const currentPath = [...path, item.name];
+    if (path.length > 0) {
+      FLATTEND_MENU_ITEMS.push({
+        ...item,
+        path: currentPath.join(" → "),
+      });
+    }
+    if (item.items && item.items.length > 0) flatten(item.items, currentPath);
+  }
+};
+
+flatten(MENU_ITEMS);

--- a/extensions/omarchy-menu/src/config/setup.ts
+++ b/extensions/omarchy-menu/src/config/setup.ts
@@ -5,7 +5,7 @@ import { MenuItem } from "./types";
 export const setup: MenuItem = {
   id: "setup",
   name: "Setup",
-  icon: Icon.Gear,
+  icon: Icon.Cog,
   items: [
     {
       id: "audio",


### PR DESCRIPTION
This PR adds support for a highly requested feature from the original Omarchy menu.

When a user searches for a command, the root search now displays all available commands. This allows users who know what they’re looking for to find commands quickly without having to dig through multiple menus.

It also updates icons that no longer exist.

https://github.com/user-attachments/assets/e9e11847-ae69-40d2-bcf7-984cf23b32b5


