### PR TITLE
fix(mise): fixes no mise error message flicker on startup

### DIFF
--- a/extensions/mise/src/hooks/useHasMiseInstalled.ts
+++ b/extensions/mise/src/hooks/useHasMiseInstalled.ts
@@ -1,13 +1,13 @@
-import { useState, useEffect } from "react";
-import { execAsync } from "../utils/execAsync";
+import { execSync } from "child_process";
+import { useMemo } from "react";
 
 export const useHasMiseInstalled = () => {
-  const [hasMiseInstalled, setHasMiseInstalled] = useState<boolean>(false);
-  useEffect(() => {
-    (async () => {
-      const hasMise = await execAsync("which mise").catch(() => false);
-      setHasMiseInstalled(!!hasMise);
-    })();
+  return useMemo(() => {
+    try {
+      const hasMise = execSync("which mise").toString().trim();
+      return !!hasMise;
+    } catch {
+      return false;
+    }
   }, []);
-  return hasMiseInstalled;
 };


### PR DESCRIPTION
This pr fixes an issue where the no mise error message will briefly flicker when the extension is launched. 