### PR TITLE
aww-switcher: added --source-color-index 0 to matugen setting

### DIFF
--- a/extensions/awww-switcher/package-lock.json
+++ b/extensions/awww-switcher/package-lock.json
@@ -1372,6 +1372,7 @@
       "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4024,6 +4025,7 @@
       "version": "4.0.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4333,6 +4335,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4612,6 +4615,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/awww-switcher/src/utils/colorgen.ts
+++ b/extensions/awww-switcher/src/utils/colorgen.ts
@@ -8,7 +8,7 @@ export const callColorGen = async (
 
   switch (ColorGen.toLowerCase()) {
     case "matugen":
-      command = `matugen image "${path}"`;
+      command = `matugen image "${path}" --source-color-index 0`;
       break;
 
     case "pywal":


### PR DESCRIPTION
updated the matugen setting to call the first source color index so it acts like it did before the update.