### PR TITLE
feat(stocks): add symbol search via Yahoo Finance

### DIFF
--- a/extensions/stocks/README.md
+++ b/extensions/stocks/README.md
@@ -6,6 +6,8 @@ A [Vicinae](https://github.com/vicinaehq/vicinae) extension for checking real-ti
 
 - Real-time stock prices
 - Price changes and percentages
+- **Symbol search** - search for any stock symbol via Yahoo Finance, with progressive price data loading
+- **Watchlist** - pre-configured symbols from preferences, with auto-refresh
 - **Color-coded indicators** - green for gains, red for losses, gray for no change
 - **Sparkline charts** showing the last 20 trading days
 - Market data like open, high, low, volume, and 52-week range
@@ -51,7 +53,9 @@ Choose the default period for price changes:
 1. Install the extension
 2. Add your stock symbols in the settings
 3. Pick your refresh rate and default time range
-4. Run the "Stocks" command to see prices
+4. Run the "Stocks" command to see your watchlist
+
+Type in the search bar to find any stock symbol. Search results show basic info first, then progressively load full price data and sparklines. Clear the search bar to return to your watchlist.
 
 Data refreshes automatically. Stocks sort with winners on top, then by biggest changes. Change the time range with the dropdown. Switch to detail view for more info like exchange status, volume, and yearly ranges.
 

--- a/extensions/stocks/src/api.ts
+++ b/extensions/stocks/src/api.ts
@@ -1,8 +1,15 @@
-import type { StockData, YahooFinanceResponse } from "./types";
+import type {
+  StockData,
+  YahooFinanceResponse,
+  YahooSearchResponse,
+  YahooSearchResult,
+} from "./types";
 import {
+  SEARCH_RESULTS_LIMIT,
   SPARKLINE_DATA_POINTS,
   USER_AGENT,
   YAHOO_FINANCE_BASE_URL,
+  YAHOO_FINANCE_SEARCH_URL,
 } from "./constants";
 
 export async function fetchSparklineData(symbol: string): Promise<number[]> {
@@ -132,5 +139,31 @@ export async function fetchStockData(
   } catch (error) {
     console.error(`Error fetching stock data for ${symbol}:`, error);
     return null;
+  }
+}
+
+export async function searchSymbols(
+  query: string,
+  limit: number = SEARCH_RESULTS_LIMIT,
+): Promise<YahooSearchResult[]> {
+  try {
+    const response = await fetch(
+      `${YAHOO_FINANCE_SEARCH_URL}?q=${encodeURIComponent(query)}&quotesCount=${limit}&newsCount=0&listsCount=0`,
+      {
+        headers: {
+          "User-Agent": USER_AGENT,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as YahooSearchResponse;
+    return (data.quotes ?? []).filter((q) => q.isYahooFinance);
+  } catch (error) {
+    console.error("Error searching symbols:", error);
+    return [];
   }
 }

--- a/extensions/stocks/src/constants.ts
+++ b/extensions/stocks/src/constants.ts
@@ -4,6 +4,11 @@ export const SPARKLINE_DATA_POINTS = 20;
 export const YAHOO_FINANCE_BASE_URL =
   "https://query1.finance.yahoo.com/v8/finance/chart/";
 
+export const YAHOO_FINANCE_SEARCH_URL =
+  "https://query2.finance.yahoo.com/v1/finance/search";
+
+export const SEARCH_RESULTS_LIMIT = 8;
+
 export const USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36";
 
 export const SPARKLINE_CHARS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];

--- a/extensions/stocks/src/hooks.ts
+++ b/extensions/stocks/src/hooks.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { StockData, YahooSearchResult } from "./types";
+import { fetchStockData, searchSymbols } from "./api";
+
+const DEBOUNCE_MS = 400;
+
+export function useStockSearch(selectedRange: string) {
+  const [searchText, setSearchText] = useState("");
+  const [suggestions, setSuggestions] = useState<YahooSearchResult[]>([]);
+  const [searchStockData, setSearchStockData] = useState<
+    Map<string, StockData>
+  >(new Map());
+  const [isSearching, setIsSearching] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const handleSearchTextChange = useCallback((text: string) => {
+    setSearchText(text);
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+
+    if (!searchText.trim()) {
+      setSuggestions([]);
+      setSearchStockData(new Map());
+      setIsSearching(false);
+      return;
+    }
+
+    setIsSearching(true);
+
+    debounceRef.current = setTimeout(async () => {
+      const results = await searchSymbols(searchText.trim());
+      setSuggestions(results);
+      setSearchStockData(new Map());
+
+      if (results.length === 0) {
+        setIsSearching(false);
+        return;
+      }
+
+      // Progressive enrichment
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setIsSearching(false);
+
+      for (const result of results) {
+        if (controller.signal.aborted) break;
+
+        const stockData = await fetchStockData(result.symbol, selectedRange);
+        if (controller.signal.aborted) break;
+
+        if (stockData) {
+          setSearchStockData((prev) => {
+            const next = new Map(prev);
+            next.set(result.symbol, stockData);
+            return next;
+          });
+        }
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+    };
+  }, [searchText, selectedRange]);
+
+  return {
+    searchText,
+    handleSearchTextChange,
+    suggestions,
+    searchStockData,
+    isSearching,
+  };
+}

--- a/extensions/stocks/src/stocks.tsx
+++ b/extensions/stocks/src/stocks.tsx
@@ -10,11 +10,127 @@ import {
   Toast,
 } from "@vicinae/api";
 import { useCallback, useEffect, useState } from "react";
-import type { StockData, Preferences } from "./types";
+import type { StockData, Preferences, YahooSearchResult } from "./types";
 import { fetchStockData } from "./api";
 import { formatPrice, generateSparkline, getColorForChange } from "./utils";
 import { StockDetail } from "./stock-detail";
 import { SPARKLINE_WIDTH } from "./constants";
+import { useStockSearch } from "./hooks";
+
+function StockListItem({
+  stock,
+  showingDetail,
+  selectedRange,
+  toggleDetails,
+}: {
+  stock: StockData;
+  showingDetail: boolean;
+  selectedRange: string;
+  toggleDetails: () => void;
+}) {
+  return (
+    <List.Item
+      key={stock.meta.symbol}
+      title={stock.meta.symbol}
+      subtitle={stock.meta.longName || stock.meta.shortName || "N/A"}
+      accessories={
+        !showingDetail
+          ? [
+              {
+                text: {
+                  value: formatPrice(
+                    stock.currentPrice,
+                    stock.meta.currency,
+                  ).padStart(10),
+                  color: getColorForChange(stock.change),
+                },
+              },
+              {
+                tag: {
+                  value: `${
+                    stock.changePercent >= 0 ? "+" : ""
+                  }${stock.changePercent.toFixed(2)}%`,
+                  color: getColorForChange(stock.change),
+                },
+              },
+              ...(stock.sparklineData && stock.sparklineData.length > 0
+                ? [
+                    {
+                      tag: {
+                        value: generateSparkline(
+                          stock.sparklineData,
+                          SPARKLINE_WIDTH,
+                        ),
+                        color: Color.SecondaryText,
+                      },
+                      tooltip: `${selectedRange} price chart`,
+                    },
+                  ]
+                : []),
+            ]
+          : []
+      }
+      detail={
+        <List.Item.Detail metadata={<StockDetail stock={stock} />} />
+      }
+      actions={
+        <ActionPanel>
+          <Action
+            title={showingDetail ? "Hide Details" : "Show Details"}
+            icon={showingDetail ? Icon.EyeDisabled : Icon.Eye}
+            onAction={toggleDetails}
+          />
+          <Action.OpenInBrowser
+            title="Open in TradingView"
+            icon={Icon.BarChart}
+            url={`https://www.tradingview.com/chart/?symbol=${stock.meta.symbol}`}
+          />
+          <Action.OpenInBrowser
+            title="Open in Yahoo Finance"
+            icon={Icon.Globe}
+            url={`https://finance.yahoo.com/quote/${stock.meta.symbol}`}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function SearchResultPlaceholder({
+  result,
+}: {
+  result: YahooSearchResult;
+}) {
+  return (
+    <List.Item
+      key={result.symbol}
+      title={result.symbol}
+      subtitle={result.longname || result.shortname || ""}
+      accessories={[
+        ...(result.exchDisp
+          ? [{ tag: { value: result.exchDisp, color: Color.SecondaryText } }]
+          : []),
+        ...(result.typeDisp
+          ? [{ tag: { value: result.typeDisp, color: Color.SecondaryText } }]
+          : []),
+      ]}
+      actions={
+        <ActionPanel>
+          <Action.OpenInBrowser
+            title="Open in TradingView"
+            icon={Icon.BarChart}
+            url={`https://www.tradingview.com/chart/?symbol=${result.symbol}`}
+          />
+          <Action.OpenInBrowser
+            title="Open in Yahoo Finance"
+            icon={Icon.Globe}
+            url={`https://finance.yahoo.com/quote/${result.symbol}`}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
 
 export default function Command() {
   const preferences = getPreferenceValues<Preferences>();
@@ -36,6 +152,14 @@ export default function Command() {
     setSelectedRangeState(range);
     LocalStorage.setItem("stocks-selected-range", range);
   }, []);
+
+  const {
+    searchText,
+    handleSearchTextChange,
+    suggestions,
+    searchStockData,
+    isSearching,
+  } = useStockSearch(selectedRange);
 
   const loadStocks = async () => {
     setLoading(true);
@@ -115,11 +239,15 @@ export default function Command() {
     setShowingDetail(!showingDetail);
   }, [showingDetail]);
 
+  const isShowingSearch = searchText.trim().length > 0;
+
   return (
     <List
-      isLoading={loading}
+      isLoading={loading || isSearching}
       searchBarPlaceholder="Search stocks..."
       isShowingDetail={showingDetail}
+      onSearchTextChange={handleSearchTextChange}
+      throttle
       searchBarAccessory={
         <List.Dropdown
           tooltip="Select time range"
@@ -136,78 +264,50 @@ export default function Command() {
         </List.Dropdown>
       }
     >
-      <List.Section
-        title="Stocks"
-        subtitle={`Last updated: ${lastRefresh.toLocaleTimeString()}`}
-      >
-        {stocks.map((stock) => (
-          <List.Item
-            key={stock.meta.symbol}
-            title={stock.meta.symbol}
-            subtitle={stock.meta.longName || stock.meta.shortName || "N/A"}
-            accessories={
-              !showingDetail
-                ? [
-                    {
-                      text: {
-                        value: formatPrice(
-                          stock.currentPrice,
-                          stock.meta.currency,
-                        ).padStart(10),
-                        color: getColorForChange(stock.change),
-                      },
-                    },
-
-                    {
-                      tag: {
-                        value: `${
-                          stock.changePercent >= 0 ? "+" : ""
-                        }${stock.changePercent.toFixed(2)}%`,
-                        color: getColorForChange(stock.change),
-                      },
-                    },
-                    ...(stock.sparklineData && stock.sparklineData.length > 0
-                      ? [
-                          {
-                            tag: {
-                              value: generateSparkline(
-                                stock.sparklineData,
-                                SPARKLINE_WIDTH,
-                              ),
-                              color: Color.SecondaryText,
-                            },
-                            tooltip: `${selectedRange} price chart`,
-                          },
-                        ]
-                      : []),
-                  ]
-                : []
-            }
-            detail={
-              <List.Item.Detail metadata={<StockDetail stock={stock} />} />
-            }
-            actions={
-              <ActionPanel>
-                <Action
-                  title={showingDetail ? "Hide Details" : "Show Details"}
-                  icon={showingDetail ? Icon.EyeDisabled : Icon.Eye}
-                  onAction={toggleDetails}
-                />
-                <Action.OpenInBrowser
-                  title="Open in TradingView"
-                  icon={Icon.BarChart}
-                  url={`https://www.tradingview.com/chart/?symbol=${stock.meta.symbol}`}
-                />
-                <Action.OpenInBrowser
-                  title="Open in Yahoo Finance"
-                  icon={Icon.Globe}
-                  url={`https://finance.yahoo.com/quote/${stock.meta.symbol}`}
-                />
-              </ActionPanel>
-            }
+      {isShowingSearch ? (
+        suggestions.length === 0 && !isSearching ? (
+          <List.EmptyView
+            title="No Results Found"
+            description="Try a different search term"
+            icon={Icon.MagnifyingGlass}
           />
-        ))}
-      </List.Section>
+        ) : (
+          <List.Section title="Search Results">
+            {suggestions.map((result) => {
+              const stockData = searchStockData.get(result.symbol);
+              return stockData ? (
+                <StockListItem
+                  key={result.symbol}
+                  stock={stockData}
+                  showingDetail={showingDetail}
+                  selectedRange={selectedRange}
+                  toggleDetails={toggleDetails}
+                />
+              ) : (
+                <SearchResultPlaceholder
+                  key={result.symbol}
+                  result={result}
+                />
+              );
+            })}
+          </List.Section>
+        )
+      ) : (
+        <List.Section
+          title="Watchlist"
+          subtitle={`Last updated: ${lastRefresh.toLocaleTimeString()}`}
+        >
+          {stocks.map((stock) => (
+            <StockListItem
+              key={stock.meta.symbol}
+              stock={stock}
+              showingDetail={showingDetail}
+              selectedRange={selectedRange}
+              toggleDetails={toggleDetails}
+            />
+          ))}
+        </List.Section>
+      )}
     </List>
   );
 }

--- a/extensions/stocks/src/types.ts
+++ b/extensions/stocks/src/types.ts
@@ -85,6 +85,20 @@ export interface YahooFinanceResponse {
   };
 }
 
+export interface YahooSearchResult {
+  symbol: string;
+  shortname?: string;
+  longname?: string;
+  quoteType: string;
+  exchDisp?: string;
+  typeDisp?: string;
+  isYahooFinance: boolean;
+}
+
+export interface YahooSearchResponse {
+  quotes: YahooSearchResult[];
+}
+
 export interface Preferences {
   symbols: string;
   refreshInterval: string;


### PR DESCRIPTION
## Summary
- Add stock symbol search using Yahoo Finance's search API with debounced input and progressive price data enrichment
- Rename existing stock list section to "Watchlist" and add a "Search Results" section when the search bar is active
- Extract shared `StockListItem` component for consistent rendering across both sections

## Test plan
- [x] Confirm watchlist displays as before when search bar is empty
- [x] Type a company name (e.g. "Apple") — search results should appear with progressive price loading
- [x] Clear search bar — watchlist should reappear
- [ ] Verify auto-refresh still works on watchlist
- [x] Verify time range dropdown works for both watchlist and search results
- [x] Verify no-results state shows empty view

🤖 Generated with [Claude Code](https://claude.com/claude-code)