### PR TITLE
feat(awww-switcher): allow `~/` in path

### DIFF
--- a/extensions/awww-switcher/package-lock.json
+++ b/extensions/awww-switcher/package-lock.json
@@ -9,7 +9,8 @@
       "dependencies": {
         "@vicinae/api": "^0.16.2",
         "image-size": "^2.0.2",
-        "jimp": "^1.6.0"
+        "jimp": "^1.6.0",
+        "untildify": "^6.0.0"
       },
       "devDependencies": {
         "typescript": "^5.9.2"
@@ -4641,6 +4642,18 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
+    },
+    "node_modules/untildify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-6.0.0.tgz",
+      "integrity": "sha512-sA2YTBvW2F463GvSbiZtso+dpuQV+B7xX9saX30SGrR5Fyx4AUcvA/zN+ShAkABKUKVyDaHECsJrHv5ToTuHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/utif2": {
       "version": "4.1.0",

--- a/extensions/awww-switcher/package.json
+++ b/extensions/awww-switcher/package.json
@@ -332,7 +332,8 @@
   "dependencies": {
     "@vicinae/api": "^0.16.2",
     "image-size": "^2.0.2",
-    "jimp": "^1.6.0"
+    "jimp": "^1.6.0",
+    "untildify": "^6.0.0"
   },
   "devDependencies": {
     "typescript": "^5.9.2"

--- a/extensions/awww-switcher/src/wpgrid.tsx
+++ b/extensions/awww-switcher/src/wpgrid.tsx
@@ -4,6 +4,7 @@ import { getImagesFromPath, Image } from "./utils/image";
 import { WindowManagement as wm } from "@vicinae/api";
 import { omniCommand } from "./utils/hyprland";
 import { createHash } from "node:crypto";
+import untildify from "untildify";
 
 // test
 
@@ -11,6 +12,7 @@ export default function DisplayGrid() {
   const [monitors, setMonitors] = useState<wm.Screen[]>([]);
   const [isWMSupported, setIsWMSupported] = useState<boolean>(true);
   const path: string = getPreferenceValues().wallpaperPath;
+  const pathExpanded: string = untildify(path);
   const awwwTransition: string = getPreferenceValues().transitionType || "fade";
   const awwwSteps: number = parseInt(getPreferenceValues().transitionSteps) || 90;
   const awwwDuration: number = parseInt(getPreferenceValues().transitionDuration) || 3;
@@ -48,7 +50,7 @@ export default function DisplayGrid() {
         style: Toast.Style.Failure,
       });
     });
-    getImagesFromPath(path)
+    getImagesFromPath(pathExpanded)
       .then((ws) => {
         setIsLoading(false);
         setWallpapers(ws);

--- a/extensions/awww-switcher/src/wprandom.tsx
+++ b/extensions/awww-switcher/src/wprandom.tsx
@@ -2,9 +2,11 @@ import { showToast, Toast, getPreferenceValues } from "@vicinae/api";
 import { getImagesFromPath, Image } from "./utils/image";
 import { omniCommand } from "./utils/hyprland";
 import { WindowManagement as wm } from "@vicinae/api";
+import untildify from "untildify";
 
 export default async function RandomWallpaper() {
   const path: string = getPreferenceValues().wallpaperPath;
+  const pathExpanded: string = untildify(path);
   const awwwTransition: string = getPreferenceValues().transitionType || "fade";
   const awwwSteps: number = parseInt(getPreferenceValues().transitionSteps) || 90;
   const awwwDuration: number = parseInt(getPreferenceValues().transitionDuration) || 3;
@@ -46,7 +48,7 @@ export default async function RandomWallpaper() {
     );
 
     const monitorNames = isWMSupported ? monitors.map((m) => m.name) : [];
-    const wallpapers: Image[] = await getImagesFromPath(path);
+    const wallpapers: Image[] = await getImagesFromPath(pathExpanded);
 
     if (wallpapers.length === 0) {
       await showToast({


### PR DESCRIPTION
Allows the user to input a path containing a `~`. 

- The path will be displayed as the user has written it. If you write `/home/user/` it will show `/home/user/`, and if you write `~/` it will show `~/`
- The path gets expanded to `/home/user/` for the backend using the `untildify` package.

Example:
<img width="614" height="251" alt="image" src="https://github.com/user-attachments/assets/2efbbd09-c9fe-4126-ac3b-a0622c2c270a" />
