### PR TITLE
aww switcher / #196 follow up

### DIFF
--- a/extensions/awww-switcher/src/utils/image.ts
+++ b/extensions/awww-switcher/src/utils/image.ts
@@ -4,7 +4,6 @@ import * as _path from "path";
 import { imageSize } from "image-size";
 import { LocalStorage as storage } from "@vicinae/api";
 import { createHash } from "node:crypto";
-import path from "node:path";
 
 const hyprpaperSupportedFormats = ["jpg", "jpeg", "png", "webp", "gif"];
 
@@ -43,7 +42,7 @@ export const getImagesFromPath = async (path: string): Promise<string[]> => {
   const imagesPaths = await parseImagesFromPath(path);
   console.timeEnd("🚀 get Images speed");
   console.log("---");
-  return imagesPaths.map((img) => _path.join(path, img));
+  return imagesPaths;
 };
 
 export const processImage = async (path: string): Promise<Image> => {
@@ -86,12 +85,12 @@ export const processImage = async (path: string): Promise<Image> => {
   }
 };
 
-async function getPrevWallpapersHash(): Promise<string | undefined> {
-  return storage.getItem("wallpapersHash");
-}
-
 async function getMetadataFromCache(): Promise<string | undefined> {
   return storage.getItem("wallpapersMetadata") ?? "";
+}
+
+async function getPrevWallpapersHash(): Promise<string | undefined> {
+  return storage.getItem("wallpapersHash");
 }
 
 const getWallpapersHash = async (path: string): Promise<string> => {
@@ -113,6 +112,13 @@ const getWallpapersHash = async (path: string): Promise<string> => {
     console.error(e);
     throw new Error("Failed to get hash of wallpapers directory");
   }
+}
+
+export const wallpaperSourceChanged = async (path: string): Promise<boolean> => {
+  let previousWallpapersHash = await getPrevWallpapersHash();
+  const currentWallpapersHash = await getWallpapersHash(path);
+  return (currentWallpapersHash == previousWallpapersHash);
+
 }
 
 // fetch images only if the source directory signature has changed and stores both the src dir signature and the wallpapers in LocalStorage
@@ -137,7 +143,7 @@ export const getImagesMetadata = async (path: string): Promise<Record<string, Im
           await Promise.all(
             batch.map((img) => {
               const key = _path.join(path, img);
-              return processImage(key).then((value) => [key, value]);
+              return processImage(key).then((value) => [img, value]);
             })
           )
         );

--- a/extensions/awww-switcher/src/wpgrid.tsx
+++ b/extensions/awww-switcher/src/wpgrid.tsx
@@ -6,6 +6,7 @@ import { omniCommand } from "./utils/hyprland";
 import { createHash } from "node:crypto";
 import { Metadata } from "@vicinae/api/dist/api/components/metadata";
 import untildify from "untildify";
+import * as _path from "path";
 // test
 
 export default function DisplayGrid() {
@@ -51,6 +52,16 @@ export default function DisplayGrid() {
       });
     });
 
+    // getImagesFromPath(pathExpanded).then((images) => {
+    //   setWallpapers(images);
+    //   setIsLoading(false);
+    // });
+    //
+    // getImagesMetadata(pathExpanded).then((metadata) => {
+    //   setWallpapersMetadata(metadata);
+    //   setIsLoading(false);
+    // });
+
     Promise.all([
       getImagesFromPath(pathExpanded),
       getImagesMetadata(pathExpanded),
@@ -85,7 +96,7 @@ export default function DisplayGrid() {
           : wallpapers.map((w) => (
             <Grid.Item
               key={w}
-              content={{ source: w }}
+              content={{ source: _path.join(pathExpanded, w) }}
               title={wallpapersMetadata[w]?.name}
               {...(preferences.showImageDetails && {
                 subtitle: `${wallpapersMetadata[w]?.width}x${wallpapersMetadata[w]?.height} • ${wallpapersMetadata[w]?.size.toFixed(2)} MB`,
@@ -98,8 +109,9 @@ export default function DisplayGrid() {
                       title={`Set '${wallpapersMetadata[w]?.name}' on All`}
                       icon={Icon.Image}
                       onAction={() => {
+                        console.log(_path.join(pathExpanded, w));
                         omniCommand(
-                          w,
+                          _path.join(pathExpanded, w),
                           "ALL",
                           awwwTransition,
                           awwwSteps,
@@ -123,7 +135,7 @@ export default function DisplayGrid() {
                             icon={Icon.ArrowsExpand}
                             onAction={() => {
                               omniCommand(
-                                w,
+                                _path.join(pathExpanded, w),
                                 `${leftMonitorName}|${rightMonitorName}`,
                                 awwwTransition,
                                 awwwSteps,
@@ -147,7 +159,7 @@ export default function DisplayGrid() {
                             icon={Icon.Monitor}
                             onAction={() => {
                               omniCommand(
-                                w,
+                                _path.join(pathExpanded, w),
                                 monitor.name,
                                 awwwTransition,
                                 awwwSteps,

--- a/extensions/awww-switcher/src/wprandom.tsx
+++ b/extensions/awww-switcher/src/wprandom.tsx
@@ -1,9 +1,10 @@
 import { showToast, Toast, getPreferenceValues } from "@vicinae/api";
-import { getImagesFromPath, Image, processImage } from "./utils/image";
+import { getImagesFromPath, Image, processImage, wallpaperSourceChanged } from "./utils/image";
 import { omniCommand } from "./utils/hyprland";
 import { WindowManagement as wm } from "@vicinae/api";
 import { LocalStorage as storage } from "@vicinae/api";
 import untildify from "untildify";
+import * as _path from "path";
 
 export default async function RandomWallpaper() {
   const path: string = getPreferenceValues().wallpaperPath;
@@ -83,8 +84,9 @@ export default async function RandomWallpaper() {
     async function getRandonmWallpaperIndex(): Promise<number> {
       // creates an array of values to generate random order and stores it as a string due to vicinae local storage type limitation
       let randomOrder = await getRandomOrder();
-      if (randomOrder == undefined) {
+      if (randomOrder == undefined || await wallpaperSourceChanged(pathExpanded)) {
         // when the random order doesn't exist in storage 
+        // or source directory has changed
         let randomOrderArray = generateRandomOrderArray();
         randomOrder = randomOrderArray.join(" ");
         storage.setItem("randomOrder", randomOrderArray.join(" "));
@@ -108,12 +110,13 @@ export default async function RandomWallpaper() {
 
     const randomIndex = await getRandonmWallpaperIndex();
     const selectedWallpaper = wallpapers[randomIndex];
-    const wallpaperInfo = await processImage(selectedWallpaper);
+    const selectedWallpaperPath = _path.join(pathExpanded, selectedWallpaper);
+    const wallpaperInfo = await processImage(_path.join(pathExpanded, selectedWallpaper));
     const isWide = wallpaperInfo.width / wallpaperInfo.height;
 
     if (isWMSupported && isWide > 1.8 && monitorNames.includes(leftMonitorName) && monitorNames.includes(rightMonitorName)) {
       omniCommand(
-        selectedWallpaper,
+        _path.join(pathExpanded, selectedWallpaper),
         `${leftMonitorName}|${rightMonitorName}`,
         awwwTransition,
         awwwSteps,
@@ -126,7 +129,7 @@ export default async function RandomWallpaper() {
       );
     } else {
       omniCommand(
-        selectedWallpaper,
+        _path.join(pathExpanded, selectedWallpaper),
         "ALL",
         awwwTransition,
         awwwSteps,


### PR DESCRIPTION
### check source directory before random selection.
example of bug it prevents : 
random order in local storage has 10 elements
user delete entries in source directory
error index out of bound.

### Store images relative path instead of absolute path
small improvement
