### PR TITLE
fix(nerdfont-search): re-enable categories

### DIFF
--- a/extensions/nerdfont-search/README.md
+++ b/extensions/nerdfont-search/README.md
@@ -15,8 +15,8 @@ Search Nerd Font icons in Vicinae and copy glyph values in multiple formats.
 
 ## Commands
 
-| Command | Description | Mode |
-| --- | --- | --- |
+| Command            | Description                                  | Mode |
+| ------------------ | -------------------------------------------- | ---- |
 | `nerdfonts-search` | Search Nerd Font icons and copy glyph values | View |
 
 ## Preferences
@@ -55,8 +55,6 @@ node --import tsx --test test/*.test.ts
 ## Search Index
 
 The extension bootstraps its icon index at runtime from Nerd Fonts upstream data and caches the serialized index locally.
-
-There are no generated search index JSON assets committed or required for build.
 
 ## Notes
 

--- a/extensions/nerdfont-search/src/constants.ts
+++ b/extensions/nerdfont-search/src/constants.ts
@@ -1,4 +1,4 @@
 export const RECENT_ICONS_LIMIT = 24;
 export const PACK_FILTER_ALL = "all";
-export const ENABLE_PACK_FILTER = false;
 export const SEARCH_RESULT_LIMIT = 200;
+export const MIN_SEARCH_LENGTH = 1;

--- a/extensions/nerdfont-search/src/filtering.ts
+++ b/extensions/nerdfont-search/src/filtering.ts
@@ -1,4 +1,4 @@
-import { PACK_FILTER_ALL, SEARCH_RESULT_LIMIT } from "./constants";
+import { MIN_SEARCH_LENGTH, PACK_FILTER_ALL, SEARCH_RESULT_LIMIT } from "./constants";
 import type { IconIndex } from "./schemas/icon-data";
 
 const SCORE_EPSILON = 0.000001;
@@ -30,7 +30,7 @@ function filterIconIndex({
 		return [];
 	}
 
-	if (searchText.length < 3) {
+	if (searchText.length < MIN_SEARCH_LENGTH) {
 		if (selectedPack === PACK_FILTER_ALL) {
 			return [];
 		}

--- a/extensions/nerdfont-search/src/nerdfonts-search.tsx
+++ b/extensions/nerdfont-search/src/nerdfonts-search.tsx
@@ -8,7 +8,7 @@ import {
   type Image,
 } from "@vicinae/api";
 import { useMemo, useState } from "react";
-import { ENABLE_PACK_FILTER, PACK_FILTER_ALL } from "./constants";
+import { MIN_SEARCH_LENGTH, PACK_FILTER_ALL } from "./constants";
 import { type IconEntry, useIconSearch } from "./hooks/useIconSearch";
 import { useRecentIcons } from "./hooks/useRecentIcons";
 import searchConfig from "./search-config.json";
@@ -91,28 +91,26 @@ function IconActions({
 export default function NerdFontSearch() {
   const [searchText, setSearchText] = useState("");
   const [selectedPack, setSelectedPack] = useState(PACK_FILTER_ALL);
-  const activePack = ENABLE_PACK_FILTER ? selectedPack : PACK_FILTER_ALL;
-
   // Use custom hooks for data management
   const { recentIcons, addRecent, clearRecent } = useRecentIcons();
   const { icons: searchResults, isLoading } = useIconSearch(
     searchText,
-    activePack,
+    selectedPack,
   );
 
   const displayIcons = useMemo(() => {
-    if (searchText.length === 0 && activePack === PACK_FILTER_ALL) {
+    if (searchText.length === 0 && selectedPack === PACK_FILTER_ALL) {
       return recentIcons.map((icon) => ({
         ...icon,
         keywords: [],
         markdown: "",
       }));
     }
-    if (searchText.length < 3 && activePack === PACK_FILTER_ALL) {
+    if (searchText.length < MIN_SEARCH_LENGTH && selectedPack === PACK_FILTER_ALL) {
       return [];
     }
     return searchResults;
-  }, [searchText, activePack, recentIcons, searchResults]);
+  }, [searchText, selectedPack, recentIcons, searchResults]);
 
   // Pack filter options
   const packFilterOptions = useMemo<{ value: string; label: string }[]>(() => {
@@ -133,52 +131,44 @@ export default function NerdFontSearch() {
       aspectRatio="1"
       isLoading={isLoading}
       onSearchTextChange={setSearchText}
-      searchBarPlaceholder="Search NerdFont Icons (min 3 characters)"
+      searchBarPlaceholder="Search NerdFont Icons"
       searchBarAccessory={
-        ENABLE_PACK_FILTER ? (
-          <Grid.Dropdown
-            tooltip="Filter by icon pack"
-            onChange={(newValue) => {
-              setSelectedPack(newValue);
-            }}
-            defaultValue={PACK_FILTER_ALL}
-          >
+        <Grid.Dropdown
+          tooltip="Filter by icon pack"
+          value={selectedPack}
+          onChange={setSelectedPack}
+        >
+          <Grid.Dropdown.Item
+            title="All icon packs"
+            value={PACK_FILTER_ALL}
+          />
+          {packFilterOptions.map((option) => (
             <Grid.Dropdown.Item
-              title="All icon packs"
-              value={PACK_FILTER_ALL}
+              key={option.value}
+              title={option.label}
+              value={option.value}
             />
-            {packFilterOptions.map((option) => (
-              <Grid.Dropdown.Item
-                key={option.value}
-                title={option.label}
-                value={option.value}
-              />
-            ))}
-          </Grid.Dropdown>
-        ) : undefined
+          ))}
+        </Grid.Dropdown>
       }
     >
       {displayIcons.length === 0 ? (
         <Grid.EmptyView
           title={
-            searchText.length > 0 && searchText.length < 3
-              ? "Keep typing..."
-              : searchText.length === 0 && activePack !== PACK_FILTER_ALL
+            searchText.length >= MIN_SEARCH_LENGTH
+              ? "No icons found"
+              : selectedPack !== PACK_FILTER_ALL
                 ? "No icons found"
-                : searchText.length >= 3
-                  ? "No icons found"
-                  : "Start searching"
+                : "Start searching"
           }
           description={
-            searchText.length > 0 && searchText.length < 3
-              ? "Enter at least 3 characters to search"
-              : searchText.length === 0 && activePack !== PACK_FILTER_ALL
+            searchText.length >= MIN_SEARCH_LENGTH
+              ? "Try a different search term or pick another icon pack"
+              : selectedPack !== PACK_FILTER_ALL
                 ? "Try selecting another icon pack"
-                : searchText.length >= 3
-                  ? "Try a different search term or pick another icon pack"
-                  : recentIcons.length > 0
-                    ? "Your recently copied icons will appear here"
-                    : "Enter at least 3 characters to search for icons"
+                : recentIcons.length > 0
+                  ? "Your recently copied icons will appear here"
+                  : "Type to search for icons"
           }
           icon={Icon.MagnifyingGlass}
         />
@@ -186,12 +176,12 @@ export default function NerdFontSearch() {
         <Grid.Section
           title={
             searchText.length === 0 &&
-            activePack === PACK_FILTER_ALL &&
+            selectedPack === PACK_FILTER_ALL &&
             recentIcons.length > 0
               ? "Recently Copied"
-              : activePack === PACK_FILTER_ALL
+              : selectedPack === PACK_FILTER_ALL
                 ? "All icon packs"
-                : (PACK_LABELS[activePack] ?? activePack.toUpperCase())
+                : (PACK_LABELS[selectedPack] ?? selectedPack.toUpperCase())
           }
           subtitle={`${displayIcons.length.toLocaleString()} icons`}
         >


### PR DESCRIPTION
## Summary

Removes feature flag and enables icon pack filtering functionality.

The reason I put this behind a flag at first was because I thought something was wrong with my integration of the `Grid.Dropdown` component, as I was unable to click the categories to activate them. 

However I noticed that this is also the case with other extensions (such as Arch Packages); ~~so I will probably open an issue for this at some point.~~

## Changes

- Remove `ENABLE_PACK_FILTER` feature flag constant
- Add `MIN_SEARCH_LENGTH` constant for search validation and adjusted it to trigger after 1 character search (akin to how it works on https://www.nerdfonts.com/cheat-sheet)
- Always show pack filter dropdown in search bar
- Update empty state messaging for search and filtering

<img width="805" height="519" alt="screenshot-screen-2026-03-23_21-40-08" src="https://github.com/user-attachments/assets/469cd7d4-b963-46a2-94d9-59aea468310e" />
