### PR TITLE
fix(agenda): fix cache, event visibility, and recurring event handling

### DIFF
--- a/extensions/agenda/package.json
+++ b/extensions/agenda/package.json
@@ -75,8 +75,8 @@
     "build": "vici build",
     "dev": "vici develop",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "TZ=UTC vitest run",
+    "test:watch": "TZ=UTC vitest"
   },
   "dependencies": {
     "@vicinae/api": "^0.16.5",

--- a/extensions/agenda/src/components/EventListItem.tsx
+++ b/extensions/agenda/src/components/EventListItem.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon, List } from "@vicinae/api";
+import { Action, ActionPanel, Icon, Keyboard, List } from "@vicinae/api";
 import type { VEvent } from "node-ical";
 import { usePreferences } from "../hooks/usePreferences";
 import { getCalendarName } from "../lib/calendar";
@@ -12,6 +12,7 @@ interface EventListItemProps {
   isShowingDetail: boolean;
   onToggleDetail: () => void;
   calendars: Calendar[];
+  onRefresh: () => void;
 }
 
 export function EventListItem({
@@ -20,6 +21,7 @@ export function EventListItem({
   isShowingDetail,
   onToggleDetail,
   calendars,
+  onRefresh,
 }: EventListItemProps) {
   const { use24Hour } = usePreferences();
   const startDate = new Date(event.start);
@@ -38,7 +40,7 @@ export function EventListItem({
         isShowingDetail
           ? undefined
           : isAllDay
-            ? ""
+            ? "All Day"
             : `${displayStart}${displayEnd ? " - " + displayEnd : ""}`
       }
       icon={Icon.Calendar}
@@ -61,6 +63,12 @@ export function EventListItem({
             title={isShowingDetail ? "Hide Details" : "Show Details"}
             onAction={onToggleDetail}
             shortcut={{ modifiers: ["ctrl"], key: "d" }}
+          />
+          <Action
+            icon={Icon.ArrowClockwise}
+            title="Refresh Calendars"
+            onAction={onRefresh}
+            shortcut={Keyboard.Shortcut.Common.Refresh}
           />
           {event.url && (
             <Action.OpenInBrowser

--- a/extensions/agenda/src/components/UpcomingEvents.tsx
+++ b/extensions/agenda/src/components/UpcomingEvents.tsx
@@ -1,8 +1,9 @@
-import { Icon, List } from "@vicinae/api";
+import { Action, ActionPanel, Icon, Keyboard, List } from "@vicinae/api";
 import { useState } from "react";
 import type { VEvent } from "node-ical";
 import { Calendar } from "../lib/types";
 import { formatDate } from "../lib/calendar";
+import { getLocalDateString } from "../lib/events";
 import { CalendarFilter } from "./CalendarFilter";
 import { EventListItem } from "./EventListItem";
 
@@ -14,6 +15,7 @@ interface UpcomingEventsProps {
   selectedCalendar: string;
   onCalendarChange: (calendar: string) => void;
   eventCalendars: Map<string, string>;
+  onRefresh: () => void;
 }
 
 export function UpcomingEvents({
@@ -24,6 +26,7 @@ export function UpcomingEvents({
   selectedCalendar,
   onCalendarChange,
   eventCalendars,
+  onRefresh,
 }: UpcomingEventsProps) {
   const [isShowingDetail, setIsShowingDetail] = useState<boolean>(false);
 
@@ -48,6 +51,17 @@ export function UpcomingEvents({
 
   const filteredEventsByDate = getFilteredEvents();
 
+  const refreshAction = (
+    <ActionPanel>
+      <Action
+        title="Refresh Calendars"
+        icon={Icon.ArrowClockwise}
+        shortcut={Keyboard.Shortcut.Common.Refresh}
+        onAction={onRefresh}
+      />
+    </ActionPanel>
+  );
+
   if (calendars.length === 0) {
     return (
       <List>
@@ -55,15 +69,21 @@ export function UpcomingEvents({
           title="No calendars configured"
           description="Add iCal URLs using the 'Add Calendar' command"
           icon={Icon.ExclamationMark}
+          actions={refreshAction}
         />
       </List>
     );
   }
 
+  const navigationTitle = lastRefresh
+    ? `Agenda · Updated ${lastRefresh.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}`
+    : "Agenda";
+
   return (
     <List
       isLoading={isLoading}
       isShowingDetail={isShowingDetail}
+      navigationTitle={navigationTitle}
       searchBarPlaceholder="Search events..."
       searchBarAccessory={
         <CalendarFilter
@@ -86,9 +106,11 @@ export function UpcomingEvents({
               : "Add calendars to get started"
           }
           icon={Icon.Calendar}
+          actions={refreshAction}
         />
       )}
       {Object.entries(filteredEventsByDate)
+        .filter(([date]) => date >= getLocalDateString(new Date()))
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([date, events]) => (
           <List.Section
@@ -107,6 +129,7 @@ export function UpcomingEvents({
                   isShowingDetail={isShowingDetail}
                   onToggleDetail={() => setIsShowingDetail((v) => !v)}
                   calendars={calendars}
+                  onRefresh={onRefresh}
                 />
               );
             })}

--- a/extensions/agenda/src/hooks/useCalendarData.ts
+++ b/extensions/agenda/src/hooks/useCalendarData.ts
@@ -8,10 +8,9 @@ import { saveToCache, loadFromCache } from "../lib/cache";
 import {
   sortEvents,
   groupEventsByDate,
-  convertRruleDate,
   calendarsChanged,
   isFutureEvent,
-  createOccurrenceUid,
+  processCalendarEvents,
 } from "../lib/eventProcessing";
 import { CACHE_KEY } from "../lib/constants";
 
@@ -47,49 +46,11 @@ export function useCalendarData(refreshInterval: number) {
 
           const icsData = await response.text();
           const parsed = parseICS(icsData);
+          const { events: calEvents, eventCalendars: calEventCalendars } =
+            processCalendarEvents(parsed, calendar.url);
 
-          for (const key in parsed) {
-            const item = parsed[key];
-            if (item.type === "VEVENT") {
-              if (item.rrule) {
-                const rangeStart = new Date();
-                const rangeEnd = new Date();
-                rangeEnd.setMonth(rangeEnd.getMonth() + 1);
-
-                const occurrences = item.rrule.between(
-                  rangeStart,
-                  rangeEnd,
-                  true,
-                );
-
-                for (const occurrenceStart of occurrences) {
-                  const occurrenceStartDate = convertRruleDate(
-                    new Date(occurrenceStart),
-                  ) as typeof item.start;
-                  const durationMs = item.end.getTime() - item.start.getTime();
-                  const occurrenceEndDate = new Date(
-                    occurrenceStartDate.getTime() + durationMs,
-                  ) as typeof item.end;
-
-                  const occurrenceEvent = {
-                    ...item,
-                    start: occurrenceStartDate,
-                    end: occurrenceEndDate,
-                    uid: createOccurrenceUid(item.uid, occurrenceStartDate),
-                    recurrenceId: occurrenceStartDate,
-                  };
-
-                  allEvents.push(occurrenceEvent as VEvent);
-                  newEventCalendars.set(occurrenceEvent.uid, calendar.url);
-                }
-              } else {
-                if (isFutureEvent(item)) {
-                  allEvents.push(item);
-                  newEventCalendars.set(item.uid, calendar.url);
-                }
-              }
-            }
-          }
+          for (const event of calEvents) allEvents.push(event);
+          for (const [uid, url] of calEventCalendars) newEventCalendars.set(uid, url);
         } catch (error) {
           console.error(
             `Failed to fetch calendar from ${calendar.url}:`,
@@ -139,7 +100,17 @@ export function useCalendarData(refreshInterval: number) {
       const cachedEventCalendars = new Map<string, string>(
         Object.entries(cached.eventCalendars),
       );
-      setEventsByDate(cached.eventsByDate);
+
+      // Filter out events that have passed since the cache was saved so the
+      // list is accurate immediately, before the network refresh completes.
+      const now = new Date();
+      const filteredEventsByDate: Record<string, VEvent[]> = {};
+      for (const [date, events] of Object.entries(cached.eventsByDate)) {
+        const upcoming = events.filter((e) => isFutureEvent(e, now));
+        if (upcoming.length > 0) filteredEventsByDate[date] = upcoming;
+      }
+
+      setEventsByDate(filteredEventsByDate);
       setEventCalendars(cachedEventCalendars);
       setLastRefresh(cached.lastRefresh);
       setIsLoading(false);

--- a/extensions/agenda/src/hooks/useCalendarData.ts
+++ b/extensions/agenda/src/hooks/useCalendarData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { LocalStorage, showToast, Toast } from "@vicinae/api";
 import { parseICS } from "node-ical";
 import type { VEvent } from "node-ical";
@@ -23,32 +23,19 @@ export function useCalendarData(refreshInterval: number) {
   const [isLoading, setIsLoading] = useState(true);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
   const [refetchTrigger, setRefetchTrigger] = useState<number>(0);
+  const [eventCalendars, setEventCalendars] = useState(new Map<string, string>());
 
-  const eventCalendarsRef = useRef(new Map<string, string>());
-
-  const fetchCalendarData = async (forceRefresh = false) => {
+  const refreshFromNetwork = async (showLoading = false) => {
     if (calendars.length === 0) {
       setEventsByDate({});
       setIsLoading(false);
       return;
     }
 
-    if (!forceRefresh) {
-      const cached = await loadFromCache(calendars);
-      if (cached) {
-        setEventsByDate(cached.eventsByDate);
-        eventCalendarsRef.current.clear();
-        for (const [key, value] of Object.entries(cached.eventCalendars)) {
-          eventCalendarsRef.current.set(key, value);
-        }
-        setIsLoading(false);
-        return;
-      }
-    }
+    if (showLoading) setIsLoading(true);
 
-    setIsLoading(true);
     const allEvents: VEvent[] = [];
-    eventCalendarsRef.current.clear();
+    const newEventCalendars = new Map<string, string>();
 
     try {
       for (const calendar of calendars) {
@@ -93,15 +80,12 @@ export function useCalendarData(refreshInterval: number) {
                   };
 
                   allEvents.push(occurrenceEvent as VEvent);
-                  eventCalendarsRef.current.set(
-                    occurrenceEvent.uid,
-                    calendar.url,
-                  );
+                  newEventCalendars.set(occurrenceEvent.uid, calendar.url);
                 }
               } else {
                 if (isFutureEvent(item)) {
                   allEvents.push(item);
-                  eventCalendarsRef.current.set(item.uid, calendar.url);
+                  newEventCalendars.set(item.uid, calendar.url);
                 }
               }
             }
@@ -125,9 +109,10 @@ export function useCalendarData(refreshInterval: number) {
       const grouped = groupEventsByDate(sortedEvents);
 
       setEventsByDate(grouped);
+      setEventCalendars(newEventCalendars);
       setLastRefresh(new Date());
 
-      await saveToCache(grouped, calendars, eventCalendarsRef.current);
+      await saveToCache(grouped, calendars, newEventCalendars);
     } catch (error) {
       console.error("Failed to fetch calendar data:", error);
       showToast({
@@ -140,13 +125,57 @@ export function useCalendarData(refreshInterval: number) {
     }
   };
 
-  useEffect(() => {
-    fetchCalendarData();
+  // Returns the effective lastRefresh time after initialization:
+  // either the cache timestamp (if fresh) or now (if a network refresh was performed).
+  const loadCacheAndRefresh = async (): Promise<Date> => {
+    if (calendars.length === 0) {
+      setEventsByDate({});
+      setIsLoading(false);
+      return new Date();
+    }
 
-    const interval = setInterval(
-      () => fetchCalendarData(false),
-      refreshInterval * 60 * 1000,
-    );
+    const cached = await loadFromCache(calendars);
+    if (cached) {
+      const cachedEventCalendars = new Map<string, string>(
+        Object.entries(cached.eventCalendars),
+      );
+      setEventsByDate(cached.eventsByDate);
+      setEventCalendars(cachedEventCalendars);
+      setLastRefresh(cached.lastRefresh);
+      setIsLoading(false);
+    }
+
+    // Only refresh from network if cache is missing or stale.
+    const cacheAge = cached ? Date.now() - cached.lastRefresh.getTime() : Infinity;
+    const refreshIntervalMs = refreshInterval * 60 * 1000;
+    if (cacheAge >= refreshIntervalMs) {
+      await refreshFromNetwork(cached === null);
+      return new Date();
+    }
+
+    return cached!.lastRefresh;
+  };
+
+  useEffect(() => {
+    const refreshIntervalMs = refreshInterval * 60 * 1000;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const startInterval = () => {
+      intervalId = setInterval(() => refreshFromNetwork(false), refreshIntervalMs);
+    };
+
+    loadCacheAndRefresh().then((lastRefreshTime) => {
+      // Schedule the first refresh to fire at the right time relative to the
+      // last successful fetch, not relative to when the extension was opened.
+      const elapsed = Date.now() - lastRefreshTime.getTime();
+      const delay = Math.max(0, refreshIntervalMs - elapsed);
+
+      timeoutId = setTimeout(() => {
+        refreshFromNetwork(false);
+        startInterval();
+      }, delay);
+    });
 
     const cacheCheckInterval = setInterval(() => {
       const currentCalendars = getCalendars();
@@ -158,7 +187,8 @@ export function useCalendarData(refreshInterval: number) {
     }, 2000);
 
     return () => {
-      clearInterval(interval);
+      if (timeoutId) clearTimeout(timeoutId);
+      if (intervalId) clearInterval(intervalId);
       clearInterval(cacheCheckInterval);
     };
   }, [refreshInterval, refetchTrigger]);
@@ -169,7 +199,7 @@ export function useCalendarData(refreshInterval: number) {
     eventsByDate,
     isLoading,
     lastRefresh,
-    eventCalendarsRef,
-    refetch: () => fetchCalendarData(true),
+    eventCalendars,
+    refetch: () => refreshFromNetwork(true),
   };
 }

--- a/extensions/agenda/src/lib/cache.ts
+++ b/extensions/agenda/src/lib/cache.ts
@@ -18,6 +18,7 @@ export const loadFromCache = async (
 ): Promise<{
   eventsByDate: Record<string, VEvent[]>;
   eventCalendars: Record<string, string>;
+  lastRefresh: Date;
 } | null> => {
   try {
     const cached = await LocalStorage.getItem(CACHE_KEY);
@@ -29,6 +30,7 @@ export const loadFromCache = async (
         return {
           eventsByDate: cacheData.eventsByDate,
           eventCalendars: cacheData.eventCalendars,
+          lastRefresh: new Date(cacheData.timestamp),
         };
       }
     }

--- a/extensions/agenda/src/lib/cacheValidation.test.ts
+++ b/extensions/agenda/src/lib/cacheValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { validateCache, buildCacheData, CacheData } from "./cacheValidation";
-import { CACHE_DURATION, CACHE_VERSION } from "./constants";
+import { CACHE_VERSION } from "./constants";
 
 describe("cacheValidation", () => {
   describe("validateCache", () => {
@@ -47,11 +47,6 @@ describe("cacheValidation", () => {
         cacheData: { cacheVersion: CACHE_VERSION + 1 },
         expectedReason: "version mismatch",
       },
-      {
-        scenario: "expired",
-        cacheData: { timestamp: Date.now() - CACHE_DURATION - 1000 },
-        expectedReason: "expired",
-      },
     ])("given cache with $scenario", ({ cacheData, expectedReason }) => {
       it(`then returns invalid with reason "${expectedReason}"`, () => {
         const result = validateCache(
@@ -63,28 +58,12 @@ describe("cacheValidation", () => {
       });
     });
 
-    describe("given cache at exact expiration boundary", () => {
-      const now = Date.now();
-      const boundaryTimestamp = now - CACHE_DURATION;
-      const cacheData = { ...validCacheData, timestamp: boundaryTimestamp };
+    describe("given a very old cache with matching calendars", () => {
+      const oldCacheData = { ...validCacheData, timestamp: 0 };
 
       describe("when validating", () => {
-        it("then returns invalid (exclusive boundary)", () => {
-          const result = validateCache(cacheData, validCalendars as any, now);
-          expect(result.valid).toBe(false);
-          expect(result.reason).toBe("expired");
-        });
-      });
-    });
-
-    describe("given cache just before expiration", () => {
-      const now = Date.now();
-      const justBeforeExpiry = now - CACHE_DURATION + 1;
-      const cacheData = { ...validCacheData, timestamp: justBeforeExpiry };
-
-      describe("when validating", () => {
-        it("then returns valid", () => {
-          const result = validateCache(cacheData, validCalendars as any, now);
+        it("then returns valid (cache does not expire by time)", () => {
+          const result = validateCache(oldCacheData, validCalendars as any);
           expect(result.valid).toBe(true);
         });
       });

--- a/extensions/agenda/src/lib/cacheValidation.ts
+++ b/extensions/agenda/src/lib/cacheValidation.ts
@@ -1,4 +1,4 @@
-import { CACHE_DURATION, CACHE_VERSION } from "./constants";
+import { CACHE_VERSION } from "./constants";
 import { Calendar } from "./types";
 import { getCalendarName } from "./calendar";
 
@@ -17,12 +17,14 @@ export interface CacheValidationResult {
 }
 
 /**
- * Validate cache data against current calendars and time constraints.
+ * Validate cache data against current calendars.
+ * Cache is considered valid as long as the calendar configuration matches —
+ * it does not expire by time. A background refresh is always performed after
+ * loading from cache to ensure data stays current.
  */
 export function validateCache(
   cacheData: Partial<CacheData>,
   calendars: Calendar[],
-  now: number = Date.now(),
 ): CacheValidationResult {
   // Check required fields
   if (!cacheData.eventCalendars) {
@@ -36,11 +38,6 @@ export function validateCache(
   // Check cache version
   if (cacheData.cacheVersion !== CACHE_VERSION) {
     return { valid: false, reason: "version mismatch" };
-  }
-
-  // Check cache expiration
-  if (now - cacheData.timestamp >= CACHE_DURATION) {
-    return { valid: false, reason: "expired" };
   }
 
   // Check calendar URLs match

--- a/extensions/agenda/src/lib/constants.test.ts
+++ b/extensions/agenda/src/lib/constants.test.ts
@@ -1,26 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { CACHE_KEY, CACHE_DURATION, CACHE_VERSION } from "./constants";
+import { CACHE_KEY, CACHE_VERSION } from "./constants";
 
 describe("constants", () => {
   describe("CACHE_KEY", () => {
     it("then is a non-empty string", () => {
       expect(typeof CACHE_KEY).toBe("string");
       expect(CACHE_KEY.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe("CACHE_DURATION", () => {
-    it("then is a positive number in milliseconds", () => {
-      expect(typeof CACHE_DURATION).toBe("number");
-      expect(CACHE_DURATION).toBeGreaterThan(0);
-    });
-
-    it("then is at least 1 minute", () => {
-      expect(CACHE_DURATION).toBeGreaterThanOrEqual(60 * 1000);
-    });
-
-    it("then is at most 1 hour", () => {
-      expect(CACHE_DURATION).toBeLessThanOrEqual(60 * 60 * 1000);
     });
   });
 

--- a/extensions/agenda/src/lib/constants.ts
+++ b/extensions/agenda/src/lib/constants.ts
@@ -1,3 +1,2 @@
 export const CACHE_KEY = "agenda-events-cache";
-export const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 export const CACHE_VERSION = 1;

--- a/extensions/agenda/src/lib/eventProcessing.test.ts
+++ b/extensions/agenda/src/lib/eventProcessing.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { parseICS } from "node-ical";
 import {
   sortEvents,
   groupEventsByDate,
@@ -6,6 +7,7 @@ import {
   calendarsChanged,
   isFutureEvent,
   createOccurrenceUid,
+  processCalendarEvents,
 } from "./eventProcessing";
 
 describe("eventProcessing", () => {
@@ -170,6 +172,34 @@ describe("eventProcessing", () => {
       });
     });
 
+    describe("given a multi-day all-day event", () => {
+      const events = [
+        {
+          uid: "multi",
+          summary: "Conference",
+          start: new Date(2024, 0, 15, 0, 0, 0), // Jan 15 midnight
+          end: new Date(2024, 0, 18, 0, 0, 0),   // Jan 18 midnight (3 days)
+        },
+      ];
+
+      describe("when grouping events", () => {
+        it("then appears in each day it spans", () => {
+          const grouped = groupEventsByDate(events);
+          expect(grouped["2024-01-15"]).toHaveLength(1);
+          expect(grouped["2024-01-16"]).toHaveLength(1);
+          expect(grouped["2024-01-17"]).toHaveLength(1);
+          expect(grouped["2024-01-18"]).toBeUndefined();
+        });
+
+        it("then the same event object appears in each group", () => {
+          const grouped = groupEventsByDate(events);
+          expect(grouped["2024-01-15"][0].uid).toBe("multi");
+          expect(grouped["2024-01-16"][0].uid).toBe("multi");
+          expect(grouped["2024-01-17"][0].uid).toBe("multi");
+        });
+      });
+    });
+
     describe("given an empty array", () => {
       describe("when grouping events", () => {
         it("then returns empty object", () => {
@@ -285,7 +315,7 @@ describe("eventProcessing", () => {
   });
 
   describe("isFutureEvent", () => {
-    describe("given an event starting after reference date", () => {
+    describe("given an event that ends after reference date", () => {
       const event = {
         uid: "1",
         summary: "Future",
@@ -301,7 +331,7 @@ describe("eventProcessing", () => {
       });
     });
 
-    describe("given an event starting before reference date", () => {
+    describe("given an event that has already ended before reference date", () => {
       const event = {
         uid: "1",
         summary: "Past",
@@ -317,18 +347,82 @@ describe("eventProcessing", () => {
       });
     });
 
-    describe("given an event starting exactly at reference date", () => {
-      const referenceDate = new Date(2024, 6, 15, 10, 0);
+    describe("given an in-progress event (started before, ends after reference date)", () => {
+      const referenceDate = new Date(2024, 6, 15, 10, 30);
       const event = {
         uid: "1",
-        summary: "Now",
+        summary: "In Progress",
         start: new Date(2024, 6, 15, 10, 0),
         end: new Date(2024, 6, 15, 11, 0),
       };
 
       describe("when checking", () => {
-        it("then returns true (inclusive)", () => {
+        it("then returns true", () => {
           expect(isFutureEvent(event, referenceDate)).toBe(true);
+        });
+      });
+    });
+
+    describe("given an all-day event for today (starts at midnight, ends at midnight tomorrow)", () => {
+      const referenceDate = new Date(2024, 6, 15, 14, 0); // 2pm today
+      const event = {
+        uid: "1",
+        summary: "All Day Today",
+        start: new Date(2024, 6, 15, 0, 0, 0), // midnight today
+        end: new Date(2024, 6, 16, 0, 0, 0),   // midnight tomorrow
+      };
+
+      describe("when checking", () => {
+        it("then returns true", () => {
+          expect(isFutureEvent(event, referenceDate)).toBe(true);
+        });
+      });
+    });
+
+    describe("given an all-day event from yesterday (ends at midnight today)", () => {
+      const referenceDate = new Date(2024, 6, 15, 14, 0); // 2pm today (July 15)
+      const event = {
+        uid: "1",
+        summary: "Yesterday All Day",
+        start: new Date(2024, 6, 14, 0, 0, 0), // midnight yesterday (July 14)
+        end: new Date(2024, 6, 15, 0, 0, 0),   // midnight today (July 15)
+      };
+
+      describe("when checking", () => {
+        it("then returns false", () => {
+          expect(isFutureEvent(event, referenceDate)).toBe(false);
+        });
+      });
+    });
+
+    describe("given a multi-day all-day event spanning today", () => {
+      const referenceDate = new Date(2024, 6, 15, 14, 0); // 2pm today (July 15)
+      const event = {
+        uid: "1",
+        summary: "Multi Day",
+        start: new Date(2024, 6, 14, 0, 0, 0), // started yesterday (July 14)
+        end: new Date(2024, 6, 17, 0, 0, 0),   // ends July 17
+      };
+
+      describe("when checking", () => {
+        it("then returns true (event is still ongoing)", () => {
+          expect(isFutureEvent(event, referenceDate)).toBe(true);
+        });
+      });
+    });
+
+    describe("given an event ending exactly at reference date", () => {
+      const referenceDate = new Date(2024, 6, 15, 11, 0);
+      const event = {
+        uid: "1",
+        summary: "Just Ended",
+        start: new Date(2024, 6, 15, 10, 0),
+        end: new Date(2024, 6, 15, 11, 0),
+      };
+
+      describe("when checking", () => {
+        it("then returns false (exclusive boundary)", () => {
+          expect(isFutureEvent(event, referenceDate)).toBe(false);
         });
       });
     });
@@ -360,6 +454,243 @@ describe("eventProcessing", () => {
           expect(uid2).toBe("recurring_2024-01-08");
           expect(uid3).toBe("recurring_2024-01-15");
           expect(new Set([uid1, uid2, uid3]).size).toBe(3);
+        });
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// processCalendarEvents
+// All dates use floating iCal times (no TZID / no Z) so they are interpreted
+// as local time. Tests run with TZ=UTC (set via the npm test script) so local
+// == UTC, making all date arithmetic unambiguous.
+// ---------------------------------------------------------------------------
+
+const CAL_URL = "https://test.example.com/calendar.ics";
+
+// A future one-off event (tomorrow at 10am)
+const ICS_FUTURE_EVENT = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:future@test
+DTSTART:20260324T100000
+DTEND:20260324T110000
+SUMMARY:Future Meeting
+END:VEVENT
+END:VCALENDAR`;
+
+// A past one-off event (yesterday at 10am)
+const ICS_PAST_EVENT = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:past@test
+DTSTART:20260322T100000
+DTEND:20260322T110000
+SUMMARY:Past Meeting
+END:VEVENT
+END:VCALENDAR`;
+
+// Today's event, 11am–noon (used for both in-progress and already-ended tests)
+const ICS_TODAY_EVENT = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:today@test
+DTSTART:20260323T110000
+DTEND:20260323T120000
+SUMMARY:Today Meeting
+END:VEVENT
+END:VCALENDAR`;
+
+// Daily recurring event, 2pm–3pm, starting today (5 occurrences)
+const ICS_RECURRING_DAILY = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:recurring@test
+DTSTART:20260323T140000
+DTEND:20260323T150000
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:Daily Meeting
+END:VEVENT
+END:VCALENDAR`;
+
+// Daily recurring event, 2am–2:30am, with today's occurrence rescheduled to 11am
+const ICS_RECURRING_WITH_OVERRIDE = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:override@test
+DTSTART:20260323T020000
+DTEND:20260323T023000
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:Early Meeting
+END:VEVENT
+BEGIN:VEVENT
+UID:override@test
+RECURRENCE-ID:20260323T020000
+DTSTART:20260323T110000
+DTEND:20260323T113000
+SUMMARY:Early Meeting
+END:VEVENT
+END:VCALENDAR`;
+
+// Daily recurring event starting yesterday (2am–2:30am), with yesterday's
+// occurrence rescheduled to today 11am. Tests the recurrences sweep path where
+// the original occurrence is before rangeStart so rrule.between() never returns it.
+const ICS_RECURRING_SWEEP_OVERRIDE = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:sweep@test
+DTSTART:20260322T020000
+DTEND:20260322T023000
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:Swept Meeting
+END:VEVENT
+BEGIN:VEVENT
+UID:sweep@test
+RECURRENCE-ID:20260322T020000
+DTSTART:20260323T110000
+DTEND:20260323T113000
+SUMMARY:Swept Meeting
+END:VEVENT
+END:VCALENDAR`;
+
+describe("processCalendarEvents", () => {
+  describe("non-recurring events", () => {
+    describe("given a future event", () => {
+      const now = new Date(2026, 2, 23, 12, 0, 0); // noon today
+
+      describe("when processing", () => {
+        it("then includes the event", () => {
+          const { events } = processCalendarEvents(parseICS(ICS_FUTURE_EVENT), CAL_URL, now);
+          expect(events).toHaveLength(1);
+          expect(events[0].uid).toBe("future@test");
+        });
+
+        it("then maps the event uid to the calendar url", () => {
+          const { events, eventCalendars } = processCalendarEvents(parseICS(ICS_FUTURE_EVENT), CAL_URL, now);
+          expect(eventCalendars.get(events[0].uid)).toBe(CAL_URL);
+        });
+      });
+    });
+
+    describe("given a past event", () => {
+      describe("when processing", () => {
+        it("then excludes the event", () => {
+          const now = new Date(2026, 2, 23, 12, 0, 0);
+          const { events } = processCalendarEvents(parseICS(ICS_PAST_EVENT), CAL_URL, now);
+          expect(events).toHaveLength(0);
+        });
+      });
+    });
+
+    describe("given an in-progress event", () => {
+      describe("when processing", () => {
+        it("then includes the event", () => {
+          const now = new Date(2026, 2, 23, 11, 30, 0); // 11:30am, event runs 11am–noon
+          const { events } = processCalendarEvents(parseICS(ICS_TODAY_EVENT), CAL_URL, now);
+          expect(events).toHaveLength(1);
+        });
+      });
+    });
+
+    describe("given an already-ended event today", () => {
+      describe("when processing", () => {
+        it("then excludes the event", () => {
+          const now = new Date(2026, 2, 23, 12, 30, 0); // 12:30pm, event ended at noon
+          const { events } = processCalendarEvents(parseICS(ICS_TODAY_EVENT), CAL_URL, now);
+          expect(events).toHaveLength(0);
+        });
+      });
+    });
+  });
+
+  describe("recurring events", () => {
+    describe("given an in-progress recurring occurrence", () => {
+      // Regression: rangeStart was `now`, so occurrences that started before
+      // now were excluded even if they hadn't ended yet.
+      describe("when processing", () => {
+        it("then includes the in-progress occurrence", () => {
+          const now = new Date(2026, 2, 23, 14, 30, 0); // 2:30pm, occurrence runs 2pm–3pm
+          const { events } = processCalendarEvents(parseICS(ICS_RECURRING_DAILY), CAL_URL, now);
+          const todayOccurrence = events.find(
+            (e) =>
+              new Date(e.start as Date).getDate() === 23 &&
+              new Date(e.start as Date).getHours() === 14,
+          );
+          expect(todayOccurrence).toBeDefined();
+        });
+      });
+    });
+
+    describe("given an already-ended recurring occurrence today", () => {
+      describe("when processing", () => {
+        it("then excludes that occurrence", () => {
+          const now = new Date(2026, 2, 23, 15, 30, 0); // 3:30pm, occurrence ended at 3pm
+          const { events } = processCalendarEvents(parseICS(ICS_RECURRING_DAILY), CAL_URL, now);
+          const todayOccurrence = events.find(
+            (e) =>
+              new Date(e.start as Date).getDate() === 23 &&
+              new Date(e.start as Date).getHours() === 14,
+          );
+          expect(todayOccurrence).toBeUndefined();
+        });
+
+        it("then still includes future occurrences", () => {
+          const now = new Date(2026, 2, 23, 15, 30, 0);
+          const { events } = processCalendarEvents(parseICS(ICS_RECURRING_DAILY), CAL_URL, now);
+          expect(events.length).toBeGreaterThan(0);
+          for (const event of events) {
+            expect(new Date(event.end as Date).getTime()).toBeGreaterThan(now.getTime());
+          }
+        });
+      });
+    });
+
+    describe("given a recurring event with a rescheduled occurrence (RECURRENCE-ID)", () => {
+      // Original: 2am–2:30am. Override: 11am–11:30am same day.
+      describe("when processing at 8am (after original, before rescheduled)", () => {
+        const now = new Date(2026, 2, 23, 8, 0, 0);
+
+        it("then includes the occurrence at the rescheduled time", () => {
+          const { events } = processCalendarEvents(parseICS(ICS_RECURRING_WITH_OVERRIDE), CAL_URL, now);
+          const todayEvents = events.filter(
+            (e) => new Date(e.start as Date).getDate() === 23,
+          );
+          expect(todayEvents).toHaveLength(1);
+          expect(new Date(todayEvents[0].start as Date).getHours()).toBe(11);
+        });
+
+        it("then does not include the original time", () => {
+          const { events } = processCalendarEvents(parseICS(ICS_RECURRING_WITH_OVERRIDE), CAL_URL, now);
+          const atOriginalTime = events.find(
+            (e) =>
+              new Date(e.start as Date).getDate() === 23 &&
+              new Date(e.start as Date).getHours() === 2,
+          );
+          expect(atOriginalTime).toBeUndefined();
+        });
+      });
+    });
+
+    describe("given a rescheduled occurrence whose original date is outside the rrule expansion range", () => {
+      // Original: yesterday 2am (before rangeStart = midnight today).
+      // Override: today 11am. The recurrences sweep must catch it.
+      describe("when processing at 9am today", () => {
+        const now = new Date(2026, 2, 23, 9, 0, 0);
+
+        it("then includes the rescheduled occurrence", () => {
+          const { events } = processCalendarEvents(parseICS(ICS_RECURRING_SWEEP_OVERRIDE), CAL_URL, now);
+          const todayEvents = events.filter(
+            (e) => new Date(e.start as Date).getDate() === 23,
+          );
+          expect(todayEvents).toHaveLength(1);
+          expect(new Date(todayEvents[0].start as Date).getHours()).toBe(11);
         });
       });
     });

--- a/extensions/agenda/src/lib/eventProcessing.ts
+++ b/extensions/agenda/src/lib/eventProcessing.ts
@@ -1,3 +1,4 @@
+import type { CalendarResponse, VEvent } from "node-ical";
 import { isAllDayEvent, getLocalDateString } from "./events";
 import { getCalendarName } from "./calendar";
 import { Calendar } from "./types";
@@ -41,6 +42,7 @@ export function sortEvents<T extends EventLike>(events: T[]): T[] {
 
 /**
  * Group events by their local date (YYYY-MM-DD).
+ * Multi-day all-day events are added to each date they span.
  */
 export function groupEventsByDate<T extends EventLike>(
   events: T[],
@@ -48,11 +50,23 @@ export function groupEventsByDate<T extends EventLike>(
   const grouped: Record<string, T[]> = {};
 
   for (const event of events) {
-    const eventDate = getLocalDateString(new Date(event.start as Date));
-    if (!grouped[eventDate]) {
-      grouped[eventDate] = [];
+    const startDate = new Date(event.start as Date);
+    const endDate = new Date(event.end as Date);
+
+    if (isAllDayEvent(startDate, endDate)) {
+      // Expand multi-day all-day events across each date they span
+      const current = new Date(startDate);
+      while (current < endDate) {
+        const dateKey = getLocalDateString(current);
+        if (!grouped[dateKey]) grouped[dateKey] = [];
+        grouped[dateKey].push(event);
+        current.setDate(current.getDate() + 1);
+      }
+    } else {
+      const dateKey = getLocalDateString(startDate);
+      if (!grouped[dateKey]) grouped[dateKey] = [];
+      grouped[dateKey].push(event);
     }
-    grouped[eventDate].push(event);
   }
 
   return grouped;
@@ -103,14 +117,23 @@ export function calendarsChanged(a: Calendar[], b: Calendar[]): boolean {
 }
 
 /**
- * Check if an event is in the future (starts after the reference date).
+ * Check if an event is upcoming relative to the reference date.
+ * For all-day events, compares by end date so that ongoing multi-day events
+ * remain visible until their last day passes. For timed events, includes
+ * in-progress events by checking the end time.
  */
 export function isFutureEvent(
   event: EventLike,
   referenceDate: Date = new Date(),
 ): boolean {
   const startDate = new Date(event.start as Date);
-  return startDate >= referenceDate;
+  const endDate = new Date(event.end as Date);
+
+  if (isAllDayEvent(startDate, endDate)) {
+    return getLocalDateString(endDate) > getLocalDateString(referenceDate);
+  }
+
+  return endDate > referenceDate;
 }
 
 /**
@@ -121,4 +144,121 @@ export function createOccurrenceUid(
   occurrenceDate: Date,
 ): string {
   return `${baseUid}_${getLocalDateString(occurrenceDate)}`;
+}
+
+/**
+ * Process a parsed iCal feed into a filtered list of upcoming events.
+ *
+ * For recurring events:
+ * - rangeStart is midnight today (wall-clock UTC) so in-progress occurrences
+ *   are included in the rrule expansion; isFutureEvent then filters out
+ *   occurrences that have already ended.
+ * - RECURRENCE-ID overrides within the expansion range replace the original
+ *   occurrence with the rescheduled time.
+ * - Overrides whose original occurrence fell before rangeStart are caught by a
+ *   secondary sweep of item.recurrences.
+ *
+ * @param now - Reference time; defaults to the current time.
+ */
+export function processCalendarEvents(
+  parsed: CalendarResponse,
+  calendarUrl: string,
+  now: Date = new Date(),
+): { events: VEvent[]; eventCalendars: Map<string, string> } {
+  const events: VEvent[] = [];
+  const eventCalendars = new Map<string, string>();
+
+  for (const key in parsed) {
+    const item = parsed[key];
+    if (item.type !== "VEVENT") continue;
+
+    if (item.rrule) {
+      // rrule.between() uses "wall clock in UTC" representation, so we must
+      // convert to that format (local time stored in UTC position) to get
+      // correct results for non-UTC timezones.
+      // rangeStart is midnight today so in-progress events (started earlier
+      // today) are included; isFutureEvent below filters out ended ones.
+      const rangeStart = new Date(Date.UTC(
+        now.getFullYear(), now.getMonth(), now.getDate(),
+        0, 0, 0,
+      ));
+      const rangeEnd = new Date(Date.UTC(
+        now.getFullYear(), now.getMonth(), now.getDate(),
+        now.getHours(), now.getMinutes(), now.getSeconds(),
+      ));
+      rangeEnd.setUTCMonth(rangeEnd.getUTCMonth() + 1);
+
+      const occurrences = item.rrule.between(rangeStart, rangeEnd, true);
+
+      // Track covered date keys so the sweep below can find uncovered overrides.
+      const rruleDateKeys = new Set<string>(
+        occurrences.map((occ) => new Date(occ).toISOString().slice(0, 10)),
+      );
+
+      for (const occurrenceStart of occurrences) {
+        // node-ical keys recurrences by the UTC date of the original occurrence
+        // (RECURRENCE-ID.toISOString().slice(0, 10)).
+        const occurrenceDateKey = new Date(occurrenceStart)
+          .toISOString()
+          .slice(0, 10);
+        const override = item.recurrences?.[occurrenceDateKey];
+
+        if (override) {
+          // This occurrence was rescheduled; use the override's times.
+          if (isFutureEvent(override, now)) {
+            const overrideEvent = {
+              ...override,
+              uid: createOccurrenceUid(item.uid, new Date(override.start as Date)),
+            };
+            events.push(overrideEvent as VEvent);
+            eventCalendars.set(overrideEvent.uid, calendarUrl);
+          }
+        } else {
+          const occurrenceStartDate = convertRruleDate(
+            new Date(occurrenceStart),
+          ) as typeof item.start;
+          const durationMs = item.end.getTime() - item.start.getTime();
+          const occurrenceEndDate = new Date(
+            occurrenceStartDate.getTime() + durationMs,
+          ) as typeof item.end;
+
+          const occurrenceEvent = {
+            ...item,
+            start: occurrenceStartDate,
+            end: occurrenceEndDate,
+            uid: createOccurrenceUid(item.uid, occurrenceStartDate),
+            recurrenceId: occurrenceStartDate,
+          };
+
+          if (isFutureEvent(occurrenceEvent, now)) {
+            events.push(occurrenceEvent as VEvent);
+            eventCalendars.set(occurrenceEvent.uid, calendarUrl);
+          }
+        }
+      }
+
+      // Sweep overrides whose original occurrence fell outside the rrule
+      // expansion window (e.g. original was before rangeStart but the
+      // rescheduled time is in the future).
+      if (item.recurrences) {
+        for (const [dateKey, override] of Object.entries(item.recurrences)) {
+          if (!rruleDateKeys.has(dateKey) && isFutureEvent(override, now)) {
+            const overrideEvent = {
+              ...override,
+              uid: createOccurrenceUid(item.uid, new Date(override.start as Date)),
+            };
+            events.push(overrideEvent as VEvent);
+            eventCalendars.set(overrideEvent.uid, calendarUrl);
+          }
+        }
+      }
+    } else {
+      if (isFutureEvent(item, now)) {
+        events.push(item);
+        eventCalendars.set(item.uid, calendarUrl);
+      }
+    }
+  }
+
+  return { events, eventCalendars };
 }

--- a/extensions/agenda/src/lib/events.test.ts
+++ b/extensions/agenda/src/lib/events.test.ts
@@ -46,8 +46,8 @@ describe("events", () => {
       const end = new Date(2024, 0, 17, 0, 0, 0); // 48 hours
 
       describe("when checking if all-day", () => {
-        it("then returns false (must be exactly 24 hours)", () => {
-          expect(isAllDayEvent(start, end)).toBe(false);
+        it("then returns true (multi-day all-day event)", () => {
+          expect(isAllDayEvent(start, end)).toBe(true);
         });
       });
     });

--- a/extensions/agenda/src/lib/events.ts
+++ b/extensions/agenda/src/lib/events.ts
@@ -6,7 +6,7 @@ export const isAllDayEvent = (start: Date, end: Date): boolean => {
     end.getHours() === 0 &&
     end.getMinutes() === 0 &&
     end.getSeconds() === 0 &&
-    end.getTime() - start.getTime() === 24 * 60 * 60 * 1000
+    end > start
   );
 };
 

--- a/extensions/agenda/src/upcoming-events.tsx
+++ b/extensions/agenda/src/upcoming-events.tsx
@@ -6,7 +6,7 @@ import { UpcomingEvents } from "./components/UpcomingEvents";
 export default function Command() {
   const { refreshInterval } = usePreferences();
 
-  const { calendars, eventsByDate, isLoading, lastRefresh, eventCalendars } =
+  const { calendars, eventsByDate, isLoading, lastRefresh, eventCalendars, refetch } =
     useCalendarData(refreshInterval);
 
   const { selectedCalendar, setSelectedCalendar } =
@@ -21,6 +21,7 @@ export default function Command() {
       selectedCalendar={selectedCalendar}
       onCalendarChange={setSelectedCalendar}
       eventCalendars={eventCalendars}
+      onRefresh={refetch}
     />
   );
 }

--- a/extensions/agenda/src/upcoming-events.tsx
+++ b/extensions/agenda/src/upcoming-events.tsx
@@ -6,7 +6,7 @@ import { UpcomingEvents } from "./components/UpcomingEvents";
 export default function Command() {
   const { refreshInterval } = usePreferences();
 
-  const { calendars, eventsByDate, isLoading, lastRefresh, eventCalendarsRef } =
+  const { calendars, eventsByDate, isLoading, lastRefresh, eventCalendars } =
     useCalendarData(refreshInterval);
 
   const { selectedCalendar, setSelectedCalendar } =
@@ -20,7 +20,7 @@ export default function Command() {
       lastRefresh={lastRefresh}
       selectedCalendar={selectedCalendar}
       onCalendarChange={setSelectedCalendar}
-      eventCalendars={eventCalendarsRef.current}
+      eventCalendars={eventCalendars}
     />
   );
 }


### PR DESCRIPTION
## Summary

Fixes several bugs in the agenda extension discovered through real-world use with iCal feeds containing recurring events, multi-day all-day events, and non-UTC timezones.

### Cache reliability
- **`eventCalendars` was a `useRef`** — changes didn't trigger re-renders, so calendar name tags on events were stale after a refresh. Changed to `useState`.
- **Cache never showed last refresh time** — `loadFromCache` wasn't returning the cache timestamp, so the smart refresh timer couldn't align to the last fetch. Fixed.
- **Cache strategy**: replaced the hard 5-minute TTL with a background refresh model — the cache is shown immediately on open, then a network refresh runs on the user's configured interval. This avoids a blank screen on every open when the cache has expired.
- **Stale events shown from cache** — on load, the cached event list is now filtered through `isFutureEvent` so events that ended since the cache was saved don't briefly appear before the network refresh completes.

### Event visibility
- **`isAllDayEvent` only recognised 24-hour events** — multi-day all-day events (e.g. a 3-day conference) were not identified as all-day. Fixed by checking midnight boundaries rather than exact 24h duration.
- **`isFutureEvent` used start time** — in-progress events (meeting started 10 mins ago, ends in 50 mins) were filtered out. Now uses end time for timed events and end date for all-day events.
- **Multi-day all-day events only appeared on their start date** — `groupEventsByDate` now expands them across every date they span.
- **Past date rows shown for ongoing multi-day events** — a 4-day event starting Monday would show Monday/Tuesday rows on Wednesday. Fixed with a render-time filter on date keys.

### Recurring events
- **`RECURRENCE-ID` overrides were ignored** — when a single occurrence of a recurring event is rescheduled, the original time was shown instead of the new time. The rrule expansion loop now checks `item.recurrences` for each occurrence and uses the override if present.
- **In-progress recurring occurrences not shown** — `rrule.between()` was called with `rangeStart = new Date()`, so occurrences that started before the current moment were excluded even if the event was still running. Fixed by using midnight today as `rangeStart` with an `isFutureEvent` guard to filter out occurrences that have already ended.
- **Rescheduled occurrences with past original dates missing** — if an occurrence's original date falls before `rangeStart`, `rrule.between()` never returns it, so the override was never processed. Added a secondary sweep of `item.recurrences` to catch these.

### UX
- All-day events show "All Day" subtitle instead of empty string
- Navigation title shows last refresh time
- Refresh action (using `Keyboard.Shortcut.Common.Refresh`) available in all list states

## Test plan

- [ ] Recurring events show correctly throughout the day, including in-progress occurrences
- [ ] Rescheduled recurring occurrences show at the new time, not the original
- [ ] Multi-day all-day events appear on each day they span
- [ ] Only today-and-future date rows are shown (no stale past rows for ongoing multi-day events)
- [ ] Opening the extension shows cached events immediately with no stale ended events
- [ ] Refresh interval setting is respected; refresh timer aligns to last fetch, not extension open time
- [ ] `npm test` passes (119 tests)