### PR TITLE
nix: add flake compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/NixOS/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,11 @@
 
     systems.url = "github:nix-systems/default";
 
+    flake-compat = {
+      url = "github:NixOS/flake-compat";
+      flake = false;
+    };
+
     vicinae = {
       url = "github:vicinaehq/vicinae";
       inputs = {


### PR DESCRIPTION
Allows nix users who are not using flakes to easily pull in the extensions.