### PR TITLE
Updating the Background Setting String in Gnome-Settings

### DIFF
--- a/extensions/gnome-settings/package.json
+++ b/extensions/gnome-settings/package.json
@@ -18,10 +18,10 @@
 			"mode": "no-view"
 		},
 		{
-			"name": "background",
-			"title": "Background",
-			"description": "Change desktop background and lock screen",
-			"keywords": ["wallpaper", "desktop", "lock screen", "slideshow"],
+			"name": "appearance",
+			"title": "Appearance",
+			"description": "Change background and accent color",
+			"keywords": ["wallpaper", "desktop", "lock screen", "slideshow", "background"],
 			"mode": "no-view"
 		},
 		{

--- a/extensions/gnome-settings/src/appearance.ts
+++ b/extensions/gnome-settings/src/appearance.ts
@@ -1,0 +1,7 @@
+import { closeMainWindow } from "@vicinae/api";
+import { spawn } from "node:child_process";
+
+export default () => {
+    closeMainWindow();
+    spawn(`gnome-control-center`, ["background"]);
+}

--- a/extensions/gnome-settings/src/background.ts
+++ b/extensions/gnome-settings/src/background.ts
@@ -1,7 +1,0 @@
-import { closeMainWindow } from "@vicinae/api";
-import { spawn } from "node:child_process";
-
-export default () => {
-    closeMainWindow();
-    spawn(`gnome-control-center`, ["background"]);
-}


### PR DESCRIPTION
In Gnome Settings, background is now called Appearance and it also let's you change the accent color of the system. I have made appropriate changes to the gnome-settings plugin to show the correct name and avoid user confusion.