### PR TITLE
fix: accept all inputs in outputs function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
       nixpkgs,
       systems,
       vicinae,
+      ...
     }:
     let
       inherit (nixpkgs) lib;


### PR DESCRIPTION
Fix regression caused by #232, by accepting all arguments in outputs.

```
       error: function 'outputs' called with unexpected argument 'flake-compat'
       at /nix/store/p427p1rnbwdj1mj2k9axc2x9hfkmh54c-source/flake.nix:29:5:
           28|   outputs =
           29|     {
             |     ^
           30|       self,
```