### PR TITLE
feat(omarchy-menu): add hibernate and logout options to system submenu

### DIFF
--- a/extensions/omarchy-menu/src/config/system.ts
+++ b/extensions/omarchy-menu/src/config/system.ts
@@ -37,5 +37,19 @@ export const system: MenuItem = {
       command:
         "omarchy-system-shutdown",
     },
+    {
+      id: "hibernate",
+      name: "Hibernate",
+      icon: "󰤁",
+      command:
+        "systemctl hibernate",
+    },
+    {
+      id: "logout",
+      name: "Logout",
+      icon: "󰜉",
+      command:
+        "omarchy-system-logout",
+    }
   ],
 };


### PR DESCRIPTION
fixes https://github.com/vicinaehq/extensions/issues/248 by adding missing hibernate and logout options to system submenu 

## *before*
<img width="881" height="588" alt="image" src="https://github.com/user-attachments/assets/bc7d6abd-de5c-4494-bbb0-d39fb1cdd3fd" />

## *after*
<img width="828" height="510" alt="image" src="https://github.com/user-attachments/assets/36f14545-8ea6-4fe0-90f5-da04bed62197" />
