### PR TITLE
fix(pulseaudio): optional application.name

### DIFF
--- a/extensions/pulseaudio/src/pactl.ts
+++ b/extensions/pulseaudio/src/pactl.ts
@@ -331,7 +331,7 @@ const pactlStreamSchema = z.object({
   description: z.string().optional(),
   mute: z.boolean(),
   properties: z.object({
-    "application.name": z.string(),
+    "application.name": z.string().optional(),
     "media.name": z.string().optional(),
     "application.process.binary": z.string().optional(),
     "node.name": z.string().optional(),


### PR DESCRIPTION
Was encountering issue with Spotify not having an application.name and would cause the extension to throw "Failed to read PulseAudio State". Doing this resolved the issue for me.