### PR TITLE
Update default search URL in package.json

### DIFF
--- a/extensions/nix/package.json
+++ b/extensions/nix/package.json
@@ -63,7 +63,7 @@
       "title": "Search URL",
       "description": "The Elasticsearch endpoint URL for Nix search",
       "type": "textfield",
-      "default": "https://search.nixos.org/backend/latest-46-nixos-unstable/_search",
+      "default": "https://search.nixos.org/backend/latest-48-nixos-unstable/_search",
       "required": true
     },
     {


### PR DESCRIPTION
The old one gives old package info.
This is the newest one