### PR TITLE
feat(github): add ssh url copy button in repositories action menus

### DIFF
--- a/extensions/github/src/myRepositories.tsx
+++ b/extensions/github/src/myRepositories.tsx
@@ -49,6 +49,10 @@ function Command() {
                 title="Copy Clone URL (HTTPS)"
                 content={repo.html_url + ".git"}
               />
+              <Action.CopyToClipboard
+                title="Copy Clone URL (SSH)"
+                content={repo.git_url}
+              />
             </ActionPanel>
           }
         />

--- a/extensions/github/src/searchRepositories.tsx
+++ b/extensions/github/src/searchRepositories.tsx
@@ -60,6 +60,10 @@ function Command() {
                 title="Copy Clone URL (HTTPS)"
                 content={repo.html_url + ".git"}
               />
+              <Action.CopyToClipboard
+                title="Copy Clone URL (SSH)"
+                content={repo.git_url}
+              />
             </ActionPanel>
           }
         />


### PR DESCRIPTION
In `github` extension, add `Copy Clone URL (SSH)` to `My Repositories` and `Search Repositories` **Actions** menus.