### PR TITLE
Order Niri workspaces by their most recent window focus timestamp

### DIFF
--- a/extensions/niri/package-lock.json
+++ b/extensions/niri/package-lock.json
@@ -7,7 +7,7 @@
       "name": "niri",
       "license": "MIT",
       "dependencies": {
-        "@vicinae/api": "0.16.6"
+        "@vicinae/api": "^0.20.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -862,7 +862,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -1063,9 +1062,9 @@
       }
     },
     "node_modules/@vicinae/api": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.16.6.tgz",
-      "integrity": "sha512-MfAXsNee/39KQJZV53+u7K2UaaSNGTHqaTBxMSil45sDdz/ga0l7uskFB2UJ1K4Q9wp8sDexlbyEyE2DnItbeg==",
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.20.7.tgz",
+      "integrity": "sha512-VQCLC0+42po4QoVbx6/RXJVweMqn1LZlKrOGHysOEMdH/dpuiSAve583yXaPEKM/Q+QZkeY+IiB3O0W0z+Rnng==",
       "license": "ISC",
       "dependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
@@ -1074,7 +1073,6 @@
         "@oclif/plugin-plugins": "^5",
         "@types/node": ">=18",
         "@types/react": "19.0.10",
-        "chalk": "^5.6.0",
         "chokidar": "^4.0.3",
         "esbuild": "^0.25.2",
         "react": "19.0.0",
@@ -1103,7 +1101,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1235,18 +1232,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -1421,7 +1406,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1475,7 +1459,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2085,7 +2068,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -2185,6 +2169,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -4537,7 +4522,6 @@
       "version": "4.0.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4873,7 +4857,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5179,7 +5162,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/niri/package.json
+++ b/extensions/niri/package.json
@@ -48,20 +48,20 @@
       "description": "Display the list of workspaces",
       "mode": "view"
     },
-     {
-       "name": "pick-color",
-       "title": "Pick Color",
-       "subtitle": "Pick a color from screen",
-       "description": "Pick a color from the screen with the mouse",
-       "mode": "no-view"
-     },
-     {
-       "name": "clear-dynamic-cast-target",
-       "title": "Clear Dynamic Cast Target",
-       "subtitle": "Clear the dynamic cast target",
-       "description": "Clear the dynamic cast target, making it show nothing",
-       "mode": "no-view"
-     }
+    {
+      "name": "pick-color",
+      "title": "Pick Color",
+      "subtitle": "Pick a color from screen",
+      "description": "Pick a color from the screen with the mouse",
+      "mode": "no-view"
+    },
+    {
+      "name": "clear-dynamic-cast-target",
+      "title": "Clear Dynamic Cast Target",
+      "subtitle": "Clear the dynamic cast target",
+      "description": "Clear the dynamic cast target, making it show nothing",
+      "mode": "no-view"
+    }
   ],
   "scripts": {
     "build": "vici build",
@@ -73,7 +73,7 @@
     "format:check": "prettier --check src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@vicinae/api": "0.16.6"
+    "@vicinae/api": "^0.20.7"
   },
   "peerDependencies": {
     "react": "^18.0.0"

--- a/extensions/niri/src/types.ts
+++ b/extensions/niri/src/types.ts
@@ -41,6 +41,10 @@ export interface Window {
   is_focused: boolean;
   is_floating: boolean;
   is_urgent: boolean;
+  focus_timestamp: {
+    secs: number;
+    nanos: number;
+  } | null;
 }
 
 export interface Workspace {

--- a/extensions/niri/src/workspaces.tsx
+++ b/extensions/niri/src/workspaces.tsx
@@ -1,39 +1,77 @@
-import { List, Icon, ActionPanel, Action } from '@vicinae/api';
+import { List, Icon, ActionPanel, Action, closeMainWindow } from '@vicinae/api';
+import { useMemo } from 'react';
 import { useNiriArrayData } from './hooks';
 import type { Workspace, Window } from './types';
 import { NiriList } from './components/NiriList';
 import { runNiriAction, showSuccess } from './utils';
 
+type WorkspaceWindows = {
+  workspace: Workspace;
+  windows: Window[];
+};
+
+function windowFocusTime(window: Window): number {
+  return window.focus_timestamp
+    ? window.focus_timestamp.secs * 1e9 + window.focus_timestamp.nanos
+    : 0;
+}
+
+function mostRecentWindowTime(windows: Window[]): number {
+  return windows.reduce((max, w) => Math.max(max, windowFocusTime(w)), 0);
+}
+
+function compareWorkspacesByFocusTime(a: WorkspaceWindows, b: WorkspaceWindows): number {
+  return mostRecentWindowTime(b.windows) - mostRecentWindowTime(a.windows);
+}
+
 export default function Workspaces() {
-  const [workspaces, workspacesLoading, handleRefresh] = useNiriArrayData<Workspace>(
+  const [workspaces, workspacesLoading, handleWorkspacesRefresh] = useNiriArrayData<Workspace>(
     'niri msg --json workspaces',
     'Failed to get workspaces'
   );
 
-  const [windows] = useNiriArrayData<Window>('niri msg --json windows', 'Failed to get windows');
+  const [windows, windowsLoading, handleWindowsRefresh] = useNiriArrayData<Window>('niri msg --json windows', 'Failed to get windows');
 
-  const loading = workspacesLoading;
+  const result = useMemo(() => {
+    if (workspacesLoading || windowsLoading) return { loading: true, sorted: [], focusedOutput: undefined };
 
-  const focusWorkspace = async (workspaceRef: string | number) => {
+    const sorted = workspaces
+      .map((workspace) => ({
+        workspace,
+        windows: windows.filter((window) => window.workspace_id === workspace.id),
+      }))
+      .sort(compareWorkspacesByFocusTime);
+
+    const focusedOutput = sorted.find((ww) => ww.workspace.is_focused)?.workspace.output;
+
+    return { loading: false, sorted, focusedOutput };
+  }, [workspaces, windows, workspacesLoading, windowsLoading]);
+
+  const focusWorkspace = async (workspace: Workspace, focusedOutput: string | undefined) => {
+    const workspaceRef = workspace.name || workspace.idx.toString();
+    if (workspace.output != focusedOutput) {
+      await runNiriAction(`focus-monitor ${workspace.output}`);
+    }
     const success = await runNiriAction(`focus-workspace ${workspaceRef}`);
     if (success) {
-      showSuccess(`Focused workspace ${workspaceRef}`);
-      await handleRefresh();
+      await handleWorkspacesRefresh();
+      await handleWindowsRefresh();
+      closeMainWindow({clearRootSearch: true});
     }
   };
 
   return (
     <NiriList
-      loading={loading}
+      loading={result.loading}
       emptyTitle="No Workspaces Found"
       emptyDescription="No workspaces are currently available."
       emptyIcon={Icon.Window}
     >
-      {workspaces.map((workspace) => {
+      {result.sorted.map((workspaceWindows) => {
+        const workspace = workspaceWindows.workspace;
         const displayName = workspace.name || `Workspace ${workspace.idx}`;
-        const workspaceWindows = windows.filter((window) => window.workspace_id === workspace.id);
-        const windowCount = workspaceWindows.length;
-        const activeWindow = windows.find((window) => window.id === workspace.active_window_id);
+        const windowCount = workspaceWindows.windows.length;
+        const activeWindow = workspaceWindows.windows.find((window) => window.id === workspace.active_window_id);
         const activeWindowTitle = activeWindow?.title;
 
         return (
@@ -55,7 +93,7 @@ export default function Workspaces() {
                 <Action
                   title="Focus Workspace"
                   icon={Icon.Eye}
-                  onAction={() => focusWorkspace(workspace.name || workspace.idx.toString())}
+                  onAction={() => focusWorkspace(workspace, result.focusedOutput)}
                 />
                 <Action.CopyToClipboard
                   title="Copy Workspace ID"


### PR DESCRIPTION
- order workspaces by their windows most recent window focus timestamp
- fix issue where it didn't work if we select a workspace in another output/monitor. We focus the output/monitor first, then select the workspace.