### PR TITLE
Add NixOS Zed binary path

### DIFF
--- a/extensions/zed-recents/src/zed-cli.ts
+++ b/extensions/zed-recents/src/zed-cli.ts
@@ -15,6 +15,7 @@ const KNOWN_ZED_PATHS = [
     "/usr/local/bin/zeditor",
     "/usr/bin/zedit",
     "/usr/local/bin/zedit",
+    "/run/current-system/sw/bin/zeditor",
     join(homedir(), ".local", "zed.app", "bin", "zed"),
 ]; // See https://zed.dev/docs/linux#community for possible binary names
 


### PR DESCRIPTION
- On NixOS, the zeditor binary is available at: `/run/current-system/sw/bin/zeditor`
- Adding this path allows the extension to detect Zed correctly on NixOS.