### PR TITLE
feat(hypr): add switch-layout command to hypr extension 

### DIFF
--- a/extensions/hypr/README.md
+++ b/extensions/hypr/README.md
@@ -12,3 +12,4 @@ Commands:
 - `monitors`: active monitors from `hyprctl -j monitors`
 - `windows`: clients from `hyprctl -j clients`
 - `keybinds`: keybinds from `hyprctl -j binds`, add description to your commands to get any meaningful information from this
+- `switch-layout`: switch the tiling layout of the active workspace via `hyprctl eval hl.workspace_rule(...)`

--- a/extensions/hypr/package.json
+++ b/extensions/hypr/package.json
@@ -52,6 +52,13 @@
       "mode": "view"
     },
     {
+      "name": "switch-layout",
+      "title": "Switch Layout",
+      "subtitle": "Switch layout for active workspace",
+      "description": "Switch the tiling layout for the active Hyprland workspace.",
+      "mode": "view"
+    },
+    {
       "name": "windows",
       "title": "Windows",
       "subtitle": "Show Hyprland windows",

--- a/extensions/hypr/src/layouts.ts
+++ b/extensions/hypr/src/layouts.ts
@@ -1,0 +1,22 @@
+import type { Layout } from './types';
+
+export const AVAILABLE_LAYOUTS = [
+  'master',
+  'dwindle',
+  'scrolling',
+  'monocle',
+] as const;
+
+export const LAYOUT_SUBTITLES: Record<Layout, string> = {
+  dwindle: 'BSPWM-like binary tree',
+  master: 'dwm-like master and stack',
+  scrolling: 'Niri-like infinite scrolling',
+  monocle: 'One window at a time, fullscreen',
+} as const;
+
+export const LAYOUT_DOC_LINKS: Record<Layout, string> = {
+  dwindle: 'https://wiki.hypr.land/Configuring/Layouts/Dwindle-Layout/',
+  master: 'https://wiki.hypr.land/Configuring/Layouts/Master-Layout/',
+  scrolling: 'https://wiki.hypr.land/Configuring/Layouts/Scrolling-Layout/',
+  monocle: 'https://wiki.hypr.land/Configuring/Layouts/Monocle-Layout/',
+} as const;

--- a/extensions/hypr/src/switch-layout.tsx
+++ b/extensions/hypr/src/switch-layout.tsx
@@ -1,0 +1,62 @@
+import { Action, ActionPanel, Icon, List } from '@vicinae/api';
+import { useHyprctlData } from './hooks';
+import {
+  AVAILABLE_LAYOUTS,
+  LAYOUT_DOC_LINKS,
+  LAYOUT_SUBTITLES,
+} from './layouts';
+import type { HyprWorkspace } from './types';
+import { capitalizeFirst, switchToLayout } from './utils';
+
+export default function SwitchLayout() {
+  const [activeWorkspace, isLoading] = useHyprctlData<
+    HyprWorkspace | undefined
+  >('activeworkspace', undefined, 'Failed to load active workspace');
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search layouts...">
+      {!activeWorkspace && !isLoading ? (
+        <List.EmptyView
+          icon={Icon.AppWindow}
+          title="No Active Workspace Found"
+          description="No Hyprland active workspace was returned by hyprctl."
+        />
+      ) : null}
+
+      {activeWorkspace ? (
+        <List.Section title="Layouts">
+          {AVAILABLE_LAYOUTS.map((layout) => {
+            const title = `${capitalizeFirst(layout)} Layout`;
+            const isCurrent = activeWorkspace.tiledLayout === layout;
+
+            return (
+              <List.Item
+                key={layout}
+                title={title}
+                subtitle={LAYOUT_SUBTITLES[layout]}
+                icon={Icon.AppWindowGrid2x2}
+                accessories={isCurrent ? [{ tag: 'Current' }] : []}
+                actions={
+                  <ActionPanel>
+                    <Action
+                      title={`Switch to ${title}`}
+                      icon={Icon.Switch}
+                      onAction={() =>
+                        switchToLayout(activeWorkspace.id, layout)
+                      }
+                    />
+                    <Action.OpenInBrowser
+                      title={`Open ${title} doc`}
+                      icon={Icon.Globe01}
+                      url={LAYOUT_DOC_LINKS[layout]}
+                    />
+                  </ActionPanel>
+                }
+              />
+            );
+          })}
+        </List.Section>
+      ) : null}
+    </List>
+  );
+}

--- a/extensions/hypr/src/types.ts
+++ b/extensions/hypr/src/types.ts
@@ -1,3 +1,7 @@
+import type { AVAILABLE_LAYOUTS } from './layouts';
+
+export type Layout = (typeof AVAILABLE_LAYOUTS)[number];
+
 export type WorkspaceRef = {
   id: number;
   name: string;

--- a/extensions/hypr/src/utils.ts
+++ b/extensions/hypr/src/utils.ts
@@ -49,7 +49,7 @@ export async function switchToLayout(
       throw normalizeHyprError(error);
     });
 
-    ensureHyprctlCommandSucceeded(stdout.toString());
+    ensureHyprctlCommandSucceeded(stdout);
     await closeMainWindow({ popToRootType: PopToRootType.Immediate });
     return true;
   } catch (error) {

--- a/extensions/hypr/src/utils.ts
+++ b/extensions/hypr/src/utils.ts
@@ -8,6 +8,7 @@ import type {
   HyprctlBind,
   HyprLayerSurface,
   HyprLayersResponse,
+  Layout,
 } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -16,16 +17,45 @@ const xkbEvdevOffset = 8;
 let evdevKeycodes: Record<number, string> | undefined;
 let hyprctlCheckPromise: Promise<void> | undefined;
 
+export function capitalizeFirst(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
 export async function getHyprctlJson<T>(command: string): Promise<T> {
   await ensureHyprRuntimeAvailable();
   const args = ['-j', ...command.split(' ').filter(Boolean)];
-  const { stdout } = await execFileAsync('hyprctl', args, { timeout: 10000 }).catch(
-    (error: unknown) => {
-      throw normalizeHyprError(error);
-    }
-  );
+  const { stdout } = await execFileAsync('hyprctl', args, {
+    timeout: 10000,
+  }).catch((error: unknown) => {
+    throw normalizeHyprError(error);
+  });
 
   return JSON.parse(stdout) as T;
+}
+
+export async function switchToLayout(
+  activeWorkspaceId: number,
+  layout: Layout
+) {
+  try {
+    await ensureHyprRuntimeAvailable();
+    const { stdout } = await execFileAsync(
+      'hyprctl',
+      getSwitchLayoutArgs(activeWorkspaceId, layout),
+      {
+        timeout: 10000,
+      }
+    ).catch((error: unknown) => {
+      throw normalizeHyprError(error);
+    });
+
+    ensureHyprctlCommandSucceeded(stdout.toString());
+    await closeMainWindow({ popToRootType: PopToRootType.Immediate });
+    return true;
+  } catch (error) {
+    handleError('Layout switch failed', error);
+    return false;
+  }
 }
 
 export async function focusHyprTarget(target: HyprFocusTarget, value: string) {
@@ -96,7 +126,9 @@ function normalizeHyprError(error: unknown) {
     .join('\n');
 
   if (execError.code === 'ENOENT') {
-    return new Error('hyprctl is required. Install Hyprland/hyprctl and try again.');
+    return new Error(
+      'hyprctl is required. Install Hyprland/hyprctl and try again.'
+    );
   }
 
   if (isMissingHyprlandSessionError(combinedOutput)) {
@@ -177,6 +209,21 @@ function getLayerName(level: number) {
 }
 
 type HyprFocusTarget = 'window' | 'monitor' | 'workspace';
+
+function getSwitchLayoutArgs(activeWorkspaceId: number, layout: Layout) {
+  return [
+    'eval',
+    `hl.workspace_rule({ workspace = "${activeWorkspaceId}", layout = "${layout}" })`,
+  ];
+}
+
+function ensureHyprctlCommandSucceeded(stdout: string) {
+  const output = stdout.trim();
+
+  if (output.startsWith('error:')) {
+    throw new Error(output);
+  }
+}
 
 function getHyprFocusCommand(target: HyprFocusTarget, value: string) {
   const luaValue = escapeLuaString(value);


### PR DESCRIPTION
Adds a `switch-layout` command to the [hypr](https://github.com/vicinaehq/extensions/blob/main/extensions/hypr/README.md) extension.

Switches the tiling layout (master, dwindle, scrolling, monocle) of the active workspace.

The layout change persists until reboot or `hyprctl reload`.

<img width="768" height="478" alt="hypr switch layout demo" src="https://github.com/user-attachments/assets/b459f0e5-a314-4b9e-a74a-515e0bc0106b" />
