### PR TITLE
feat(hypr): add switch-layout command to hypr extension

### DIFF
--- a/extensions/hypr/README.md
+++ b/extensions/hypr/README.md
@@ -12,3 +12,4 @@ Commands:
 - `monitors`: active monitors from `hyprctl -j monitors`
 - `windows`: clients from `hyprctl -j clients`
 - `keybinds`: keybinds from `hyprctl -j binds`, add description to your commands to get any meaningful information from this
+- `switch-layout`: switch the tiling layout of the active workspace via `hyprctl eval hl.workspace_rule(...)`

--- a/extensions/hypr/package-lock.json
+++ b/extensions/hypr/package-lock.json
@@ -11,13 +11,14 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
+        "@types/node": "^26.2.0",
         "typescript": "^5.9.2"
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
-      "integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.16.tgz",
+      "integrity": "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -31,20 +32,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.2",
-        "@biomejs/cli-darwin-x64": "2.5.2",
-        "@biomejs/cli-linux-arm64": "2.5.2",
-        "@biomejs/cli-linux-arm64-musl": "2.5.2",
-        "@biomejs/cli-linux-x64": "2.5.2",
-        "@biomejs/cli-linux-x64-musl": "2.5.2",
-        "@biomejs/cli-win32-arm64": "2.5.2",
-        "@biomejs/cli-win32-x64": "2.5.2"
+        "@biomejs/cli-darwin-arm64": "2.4.16",
+        "@biomejs/cli-darwin-x64": "2.4.16",
+        "@biomejs/cli-linux-arm64": "2.4.16",
+        "@biomejs/cli-linux-arm64-musl": "2.4.16",
+        "@biomejs/cli-linux-x64": "2.4.16",
+        "@biomejs/cli-linux-x64-musl": "2.4.16",
+        "@biomejs/cli-win32-arm64": "2.4.16",
+        "@biomejs/cli-win32-x64": "2.4.16"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz",
+      "integrity": "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==",
       "cpu": [
         "arm64"
       ],
@@ -59,9 +60,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz",
+      "integrity": "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==",
       "cpu": [
         "x64"
       ],
@@ -76,16 +77,13 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz",
+      "integrity": "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -96,16 +94,13 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
-      "integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz",
+      "integrity": "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -116,16 +111,13 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz",
+      "integrity": "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -136,16 +128,13 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
-      "integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz",
+      "integrity": "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -156,9 +145,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
-      "integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz",
+      "integrity": "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==",
       "cpu": [
         "arm64"
       ],
@@ -173,9 +162,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz",
+      "integrity": "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==",
       "cpu": [
         "x64"
       ],
@@ -606,9 +595,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -616,32 +605,31 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
-      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+      "version": "19.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
+      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@vicinae/api": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.22.2.tgz",
-      "integrity": "sha512-0nNpeV4LAqgewJCIuTIpTG85Qc4Ku3Jh0b/lyIpiFNt7SehTeibscUmWVOuUuU4PuzpoFXqYTPDN3hfa/dNx9Q==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.22.3.tgz",
+      "integrity": "sha512-wyw/gmfVXb2QkuaLXu8351fYsPVfJqQWDI6rBP8j9QqSn+qfaNaJ4bviR3NYwyYLcd6UoZrUkF26vo6OhanTZw==",
       "license": "ISC",
       "dependencies": {
+        "@types/react": "19.1.17",
         "chokidar": "^4.0.3",
         "esbuild": "^0.25.2",
-        "react": "^19.0.0",
+        "react": "19.1.1",
         "zod": "^4.0.17"
       },
       "bin": {
         "vici": "dist/bin.js"
       },
       "peerDependencies": {
-        "@types/node": ">=18",
-        "@types/react": "19.0.10"
+        "@types/node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -663,8 +651,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -708,9 +695,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -747,8 +734,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/extensions/hypr/package.json
+++ b/extensions/hypr/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/vicinaehq/vicinae/refs/heads/main/extra/schemas/extension.json",
   "name": "hypr",
-  "description": "Inspect Hyprland monitors, workspaces, windows, layers, outputs, and keybinds.",
+  "description": "Inspect Hyprland monitors, workspaces, windows, layers, outputs, and keybinds, and switch workspace layouts.",
   "categories": [
     "System"
   ],
@@ -50,6 +50,13 @@
       "title": "Monitors",
       "subtitle": "Show active Hyprland monitors",
       "description": "Display active Hyprland monitors.",
+      "mode": "view"
+    },
+    {
+      "name": "switch-layout",
+      "title": "Switch Layout",
+      "subtitle": "Switch layout for active workspace",
+      "description": "Switch the tiling layout for the active Hyprland workspace.",
       "mode": "view"
     },
     {

--- a/extensions/hypr/package.json
+++ b/extensions/hypr/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/vicinaehq/vicinae/refs/heads/main/extra/schemas/extension.json",
   "name": "hypr",
-  "description": "Inspect Hyprland monitors, workspaces, windows, layers, outputs, and keybinds.",
+  "description": "Inspect Hyprland monitors, workspaces, windows, layers, outputs, and keybinds, and switch workspace layouts.",
   "categories": [
     "System"
   ],
@@ -49,6 +49,13 @@
       "title": "Monitors",
       "subtitle": "Show active Hyprland monitors",
       "description": "Display active Hyprland monitors.",
+      "mode": "view"
+    },
+    {
+      "name": "switch-layout",
+      "title": "Switch Layout",
+      "subtitle": "Switch layout for active workspace",
+      "description": "Switch the tiling layout for the active Hyprland workspace.",
       "mode": "view"
     },
     {

--- a/extensions/hypr/package.json
+++ b/extensions/hypr/package.json
@@ -6,7 +6,9 @@
     "System"
   ],
   "license": "MIT",
-  "platforms": ["Linux"],
+  "platforms": [
+    "Linux"
+  ],
   "author": "nino-mau",
   "contributors": [],
   "scripts": {
@@ -20,6 +22,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
+    "@types/node": "^26.2.0",
     "typescript": "^5.9.2"
   },
   "icon": "extension_icon.png",

--- a/extensions/hypr/src/layouts.ts
+++ b/extensions/hypr/src/layouts.ts
@@ -1,0 +1,22 @@
+import type { Layout } from './types';
+
+export const AVAILABLE_LAYOUTS = [
+  'master',
+  'dwindle',
+  'scrolling',
+  'monocle',
+] as const;
+
+export const LAYOUT_SUBTITLES: Record<Layout, string> = {
+  dwindle: 'BSPWM-like binary tree',
+  master: 'dwm-like master and stack',
+  scrolling: 'Niri-like infinite scrolling',
+  monocle: 'One window at a time, fullscreen',
+} as const;
+
+export const LAYOUT_DOC_LINKS: Record<Layout, string> = {
+  dwindle: 'https://wiki.hypr.land/Configuring/Layouts/Dwindle-Layout/',
+  master: 'https://wiki.hypr.land/Configuring/Layouts/Master-Layout/',
+  scrolling: 'https://wiki.hypr.land/Configuring/Layouts/Scrolling-Layout/',
+  monocle: 'https://wiki.hypr.land/Configuring/Layouts/Monocle-Layout/',
+} as const;

--- a/extensions/hypr/src/switch-layout.tsx
+++ b/extensions/hypr/src/switch-layout.tsx
@@ -1,0 +1,60 @@
+import { Action, ActionPanel, Icon, List } from '@vicinae/api';
+import { useHyprctlData } from './hooks';
+import {
+  AVAILABLE_LAYOUTS,
+  LAYOUT_DOC_LINKS,
+  LAYOUT_SUBTITLES,
+} from './layouts';
+import type { HyprWorkspace } from './types';
+import { capitalizeFirst, switchToLayout } from './utils';
+
+export default function SwitchLayout() {
+  const [activeWorkspace, isLoading] = useHyprctlData<
+    HyprWorkspace | undefined
+  >('activeworkspace', undefined, 'Failed to load active workspace');
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search layouts...">
+      {!activeWorkspace && !isLoading ? (
+        <List.EmptyView
+          icon={Icon.AppWindow}
+          title="No Active Workspace Found"
+          description="No Hyprland active workspace was returned by hyprctl."
+        />
+      ) : null}
+
+      {activeWorkspace ? (
+        <List.Section title="Layouts">
+          {AVAILABLE_LAYOUTS.map((layout) => {
+            const title = `${capitalizeFirst(layout)} Layout`;
+            const isCurrent = activeWorkspace.tiledLayout === layout;
+
+            return (
+              <List.Item
+                key={layout}
+                title={title}
+                subtitle={LAYOUT_SUBTITLES[layout]}
+                icon={Icon.AppWindowGrid2x2}
+                accessories={isCurrent ? [{ tag: 'Current' }] : []}
+                actions={
+                  <ActionPanel>
+                    <Action
+                      title={`Switch to ${title}`}
+                      icon={Icon.Switch}
+                      onAction={() => switchToLayout(layout)}
+                    />
+                    <Action.OpenInBrowser
+                      title={`Open ${title} doc`}
+                      icon={Icon.Globe01}
+                      url={LAYOUT_DOC_LINKS[layout]}
+                    />
+                  </ActionPanel>
+                }
+              />
+            );
+          })}
+        </List.Section>
+      ) : null}
+    </List>
+  );
+}

--- a/extensions/hypr/src/types.ts
+++ b/extensions/hypr/src/types.ts
@@ -1,3 +1,7 @@
+import type { AVAILABLE_LAYOUTS } from './layouts';
+
+export type Layout = (typeof AVAILABLE_LAYOUTS)[number];
+
 export type WorkspaceRef = {
   id: number;
   name: string;

--- a/extensions/hypr/src/utils.ts
+++ b/extensions/hypr/src/utils.ts
@@ -8,6 +8,8 @@ import type {
   HyprctlBind,
   HyprLayerSurface,
   HyprLayersResponse,
+  HyprWorkspace,
+  Layout,
 } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -16,16 +18,43 @@ const xkbEvdevOffset = 8;
 let evdevKeycodes: Record<number, string> | undefined;
 let hyprctlCheckPromise: Promise<void> | undefined;
 
+export function capitalizeFirst(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
 export async function getHyprctlJson<T>(command: string): Promise<T> {
   await ensureHyprRuntimeAvailable();
   const args = ['-j', ...command.split(' ').filter(Boolean)];
-  const { stdout } = await execFileAsync('hyprctl', args, { timeout: 10000 }).catch(
-    (error: unknown) => {
-      throw normalizeHyprError(error);
-    }
-  );
+  const { stdout } = await execFileAsync('hyprctl', args, {
+    timeout: 10000,
+  }).catch((error: unknown) => {
+    throw normalizeHyprError(error);
+  });
 
   return JSON.parse(stdout) as T;
+}
+
+export async function switchToLayout(layout: Layout) {
+  try {
+    const activeWorkspace =
+      await getHyprctlJson<HyprWorkspace>('activeworkspace');
+    const { stdout } = await execFileAsync(
+      'hyprctl',
+      getSwitchLayoutArgs(activeWorkspace.id, layout),
+      {
+        timeout: 10000,
+      }
+    ).catch((error: unknown) => {
+      throw normalizeHyprError(error);
+    });
+
+    ensureHyprctlCommandSucceeded(stdout);
+    await closeMainWindow({ popToRootType: PopToRootType.Immediate });
+    return true;
+  } catch (error) {
+    handleError('Layout switch failed', error);
+    return false;
+  }
 }
 
 export async function focusHyprTarget(target: HyprFocusTarget, value: string) {
@@ -96,7 +125,9 @@ function normalizeHyprError(error: unknown) {
     .join('\n');
 
   if (execError.code === 'ENOENT') {
-    return new Error('hyprctl is required. Install Hyprland/hyprctl and try again.');
+    return new Error(
+      'hyprctl is required. Install Hyprland/hyprctl and try again.'
+    );
   }
 
   if (isMissingHyprlandSessionError(combinedOutput)) {
@@ -177,6 +208,21 @@ function getLayerName(level: number) {
 }
 
 type HyprFocusTarget = 'window' | 'monitor' | 'workspace';
+
+function getSwitchLayoutArgs(activeWorkspaceId: number, layout: Layout) {
+  return [
+    'eval',
+    `hl.workspace_rule({ workspace = "${activeWorkspaceId}", layout = "${layout}" })`,
+  ];
+}
+
+function ensureHyprctlCommandSucceeded(stdout: string) {
+  const output = stdout.trim();
+
+  if (output.startsWith('error:')) {
+    throw new Error(output);
+  }
+}
 
 function getHyprFocusCommand(target: HyprFocusTarget, value: string) {
   const luaValue = escapeLuaString(value);


### PR DESCRIPTION
Adds a `switch-layout` command to the [hypr](https://github.com/vicinaehq/extensions/blob/main/extensions/hypr/README.md) extension.

Switches the tiling layout (master, dwindle, scrolling, monocle) of the active workspace.

The layout change persists until reboot or `hyprctl reload`.

<img width="768" height="478" alt="hypr switch layout demo" src="https://github.com/user-attachments/assets/3340be31-34b3-4585-8eaa-d316c325f51f" />

