### PR TITLE
fix(timer): use env-style shebang

### DIFF
--- a/extensions/timer/src/index.tsx
+++ b/extensions/timer/src/index.tsx
@@ -72,7 +72,7 @@ export default function TimerCommand() {
     const id = Date.now().toString()
     const unitName = `vicinae-timer-${id}`
 
-    const cmd = `systemd-run --user --on-active="${seconds}s" --timer-property=AccuracySec=1s --unit="${unitName}" -- /bin/bash -c 'notify-send -a "Vicinae" "Timer" "${timerNote}"'`
+    const cmd = `systemd-run --user --on-active="${seconds}s" --timer-property=AccuracySec=1s --unit="${unitName}" -- /usr/bin/env bash -c 'notify-send -a "Vicinae" "Timer" "${timerNote}"'`
 
     exec(cmd, error => {
       if (error) {


### PR DESCRIPTION
the timer silently fails on NixOS due to bash not being located in /bin/bash