### PR TITLE
vscode-recents: Fix vscodium shared path

### DIFF
--- a/extensions/vscode-recents/src/constants.ts
+++ b/extensions/vscode-recents/src/constants.ts
@@ -19,7 +19,7 @@ export const VSCODE_EXECUTABLES: Record<string, string> = {
 const VSCODE_SHARED_STORAGE_DIRS: Record<string, string> = {
     "Code": ".vscode-shared",
     "Cursor": ".cursor-shared",
-    "VSCodium": ".vscodium-shared",
+    "VSCodium": ".vscode-oss-shared",
     "Antigravity": ".antigravity-shared",
     "Code - Insiders": ".vscode-insiders-shared",
 };


### PR DESCRIPTION
This PR updates the path for vscodium 
See: https://github.com/vicinaehq/extensions/issues/264#issuecomment-4699355396