### PR TITLE
fix(kde-system-settings): replace removed Icon.Gear with Icon.Cog

### DIFF
--- a/extensions/kde-system-settings/src/search-kde-settings.tsx
+++ b/extensions/kde-system-settings/src/search-kde-settings.tsx
@@ -112,7 +112,7 @@ export default function SearchSettings(props: LaunchProps) {
                 <ActionPanel>
                   <Action
                     title="Open Settings Module"
-                    icon={Icon.Gear}
+                    icon={Icon.Cog}
                     onAction={() =>
                       openKCMModule(module.name, module.execCommand)
                     }


### PR DESCRIPTION
`Icon.Gear` was removed from the icon set in newer `@vicinae/api` versions (the equivalent member is now `Icon.Cog`), so the extension fails `tsc` against the bumped ^0.22.2 dependency, and at runtime the "Open Settings Module" action renders without an icon since `Icon.Gear` evaluates to `undefined`.

Replaces it with `Icon.Cog`. Verified `npm run typecheck`, `vici build`, and `vici lint` pass, and the action icon renders again on vicinae v0.22.3.