### PR TITLE
fix(zed-recents): use complete file/ssh uri when opening project

### DIFF
--- a/extensions/zed-recents/src/zed-cli.ts
+++ b/extensions/zed-recents/src/zed-cli.ts
@@ -65,7 +65,7 @@ export async function openProject(project: RecentProject): Promise<void> {
 function buildUri(project: RecentProject): string {
     if (!project.remote) {
         const uri = new URL("file:///");
-        uri.pathname = project.path;
+        uri.pathname = project.path.replace(/%/g, "%25");
         return uri.toString();
     }
 
@@ -76,7 +76,7 @@ function buildUri(project: RecentProject): string {
     const isRawIpv6 = project.remote.host.includes(":") && !project.remote.host.startsWith("[");
     const safeHost = isRawIpv6 ? `[${project.remote.host}]` : project.remote.host;
     const uri = new URL(`${project.remote.kind}://${safeHost}`);
-    uri.pathname = project.path;
+    uri.pathname = project.path.replace(/%/g, "%25");
 
     if (project.remote.user) {
         uri.username = project.remote.user;

--- a/extensions/zed-recents/src/zed-cli.ts
+++ b/extensions/zed-recents/src/zed-cli.ts
@@ -64,16 +64,28 @@ export async function openProject(project: RecentProject): Promise<void> {
 
 function buildUri(project: RecentProject): string {
     if (!project.remote) {
-        return `file://${project.path}`;
+        const uri = new URL("file:///");
+        uri.pathname = project.path;
+        return uri.toString();
     }
 
-    if (project.remote.kind === "ssh") {
-        const userPart = project.remote.user ? `${project.remote.user}@` : "";
-        const portPart = project.remote.port ? `:${project.remote.port}` : "";
-        return `${project.remote.kind}://${userPart}${project.remote.host}${portPart}${project.path}`;
+    if (!project.remote.host) {
+        throw new Error("Remote host is missing");
     }
 
-    throw new Error(`Unsupported remote kind: ${project.remote.kind}`);
+    const isRawIpv6 = project.remote.host.includes(":") && !project.remote.host.startsWith("[");
+    const safeHost = isRawIpv6 ? `[${project.remote.host}]` : project.remote.host;
+    const uri = new URL(`${project.remote.kind}://${safeHost}`);
+    uri.pathname = project.path;
+
+    if (project.remote.user) {
+        uri.username = project.remote.user;
+    }
+    if (project.remote.port) {
+        uri.port = project.remote.port.toString();
+    }
+
+    return uri.toString();
 }
 
 async function resolveExecutable(): Promise<string | undefined> {

--- a/extensions/zed-recents/src/zed-cli.ts
+++ b/extensions/zed-recents/src/zed-cli.ts
@@ -39,7 +39,17 @@ export async function openProject(project: RecentProject): Promise<void> {
         args.push("--add");
     }
 
-    args.push(project.path);
+    try {
+        const uri = buildUri(project);
+        args.push(uri);
+    } catch (error) {
+        await showToast({
+            style: Toast.Style.Failure,
+            title: "Failed to build URI",
+            message: `Could not build URI for project: ${error}`,
+        });
+        return;
+    }
 
     try {
         await spawnDetached(resolvedPath, args);
@@ -50,6 +60,20 @@ export async function openProject(project: RecentProject): Promise<void> {
             message: `Could not open project in Zed: ${error}`,
         });
     }
+}
+
+function buildUri(project: RecentProject): string {
+    if (!project.remote) {
+        return `file://${project.path}`;
+    }
+
+    if (project.remote.kind === "ssh") {
+        const userPart = project.remote.user ? `${project.remote.user}@` : "";
+        const portPart = project.remote.port ? `:${project.remote.port}` : "";
+        return `${project.remote.kind}://${userPart}${project.remote.host}${portPart}${project.path}`;
+    }
+
+    throw new Error(`Unsupported remote kind: ${project.remote.kind}`);
 }
 
 async function resolveExecutable(): Promise<string | undefined> {


### PR DESCRIPTION
Build a complete file/ssh uri when opening a project.
This fixes the issue that remote workspaces where opened using local path instead of the remote project #317 