### PR TITLE
fix(pass): improve macOS gpg support

### DIFF
--- a/extensions/pass/README.md
+++ b/extensions/pass/README.md
@@ -4,13 +4,14 @@
 
 # Vicinae Pass
 
-Vicinae Pass lets you browse, decrypt, and copy secrets that are saved in your GNU pass vault directly from Vicinae on Linux. It mirrors the Raycast experience while embracing the Vicinae component and toast system.
+Vicinae Pass lets you browse, decrypt, and copy secrets that are saved in your GNU pass vault directly from Vicinae on Linux and macOS. It mirrors the Raycast experience while embracing the Vicinae component and toast system.
 
 ## Requirements
 
 - [pass](https://www.passwordstore.org/) configured with your GPG key
 - `gpg` available in your `$PATH`
 - [`oathtool`](https://manpages.debian.org/oathtool) (optional) for generating OTP codes from `otpauth://` lines
+- On macOS, Homebrew installs typically require `/opt/homebrew/bin` or `/usr/local/bin` to be visible to Vicinae
 
 ## Commands
 
@@ -22,9 +23,10 @@ Vicinae Pass lets you browse, decrypt, and copy secrets that are saved in your G
 
 - **Pass Store Location** – Absolute path to your `~/.password-store` directory (defaults to `~/.password-store`).
 - **GPG Passphrase** – Optional passphrase that unlocks your key via GPG loopback mode.
-- **Additional PATH Entries** – Colon-separated directories appended to `PATH` before running `gpg` or `oathtool`.
+- **Additional PATH Entries** – Colon-separated directories prepended to `PATH` before running `gpg` or `oathtool`.
 - **Prioritize OTP After Password** – When enabled, OTP entries jump to the top after you copy a password to speed up two-factor flows.
-- **Last Used TTL (seconds)** – How long the last-used entry is pinned to the top of the list (defaults to 120 seconds).- **File Schema** - Basic, optional JSON to 'describe' your `pass` file layout (defaults to empty, example below).
+- **Last Used TTL (seconds)** – How long the last-used entry is pinned to the top of the list (defaults to 120 seconds).
+- **File Schema** - Basic, optional JSON to 'describe' your `pass` file layout (defaults to empty, example below).
 
 ## Usage
 
@@ -62,4 +64,11 @@ Use `npm run build` to assemble a production bundle that Vicinae can import.
 
 - Make sure your password store is initialized (`pass init ...`) and contains `.gpg` files.
 - If GPG prompts for a passphrase, add it to the extension preferences or ensure your agent has the key unlocked.
-- Install `oathtool` if you want OTP generation: `sudo apt install oathtool` (Debian/Ubuntu) or `sudo pacman -S oathtool` (Arch).
+- Install `oathtool` if you want OTP generation: `sudo apt install oathtool` (Debian/Ubuntu), `sudo pacman -S oathtool` (Arch), or `brew install oath-toolkit` (macOS).
+- On macOS, install GPG and pinentry with `brew install gnupg pinentry-mac`, then configure `~/.gnupg/gpg-agent.conf` if passphrase prompts fail:
+  ```conf
+  pinentry-program /opt/homebrew/bin/pinentry-mac
+  allow-loopback-pinentry
+  ```
+  Restart the agent with `gpgconf --kill gpg-agent`.
+- If Vicinae cannot find `gpg` or `oathtool` on macOS, set **Additional PATH Entries** to `/opt/homebrew/bin:/usr/local/bin:/opt/local/bin`.

--- a/extensions/pass/README.md
+++ b/extensions/pass/README.md
@@ -63,7 +63,7 @@ Use `npm run build` to assemble a production bundle that Vicinae can import.
 ## Troubleshooting
 
 - Make sure your password store is initialized (`pass init ...`) and contains `.gpg` files.
-- If GPG prompts for a passphrase, add it to the extension preferences or ensure your agent has the key unlocked.
+- If GPG prompts for a passphrase, either unlock the key with your system pinentry/agent or use **Enter GPG Passphrase** from the error view. If a saved passphrase fails, **Try System Pinentry** retries without loopback. Saving **GPG Passphrase** in preferences uses GPG loopback mode.
 - Install `oathtool` if you want OTP generation: `sudo apt install oathtool` (Debian/Ubuntu), `sudo pacman -S oathtool` (Arch), or `brew install oath-toolkit` (macOS).
 - On macOS, install GPG and pinentry with `brew install gnupg pinentry-mac`, then configure `~/.gnupg/gpg-agent.conf` if passphrase prompts fail:
   ```conf
@@ -71,4 +71,4 @@ Use `npm run build` to assemble a production bundle that Vicinae can import.
   allow-loopback-pinentry
   ```
   Restart the agent with `gpgconf --kill gpg-agent`.
-- If Vicinae cannot find `gpg` or `oathtool` on macOS, set **Additional PATH Entries** to `/opt/homebrew/bin:/usr/local/bin:/opt/local/bin`.
+- If Vicinae cannot find `gpg` or `oathtool` on macOS, set **Additional PATH Entries** to `/opt/homebrew/bin:/usr/local/bin:/opt/local/bin`. Nix users can add `~/.nix-profile/bin` or `/etc/profiles/per-user/$USER/bin` if needed.

--- a/extensions/pass/package.json
+++ b/extensions/pass/package.json
@@ -42,7 +42,7 @@
       "name": "additionalPath",
       "type": "textfield",
       "title": "Additional PATH Entries",
-      "description": "Colon separated paths appended to PATH before invoking gpg/oathtool",
+      "description": "Colon separated paths prepended to PATH before invoking gpg/oathtool",
       "default": "",
       "required": false
     },

--- a/extensions/pass/src/pass.tsx
+++ b/extensions/pass/src/pass.tsx
@@ -13,7 +13,6 @@ import { getPreferences } from "@/preferences";
 import {
   listPasswordEntries,
   decryptPasswordEntry,
-  isGpgUnlocked,
 } from "@/services/passctl";
 import { getLastUsedPassword } from "@/storage/last-used";
 import { buildPasswordOptions } from "@/utils/password";
@@ -34,13 +33,11 @@ export default function Command() {
     isLoading: true,
   });
 
-  const [locked, setlocked] = useState(true);
   const { push } = useNavigation();
 
   const refresh = useCallback(async () => {
     setState((prev) => ({ ...prev, isLoading: true, error: undefined }));
     try {
-      setlocked(await isGpgUnlocked(preferences));
       const [entries, lastUsed] = await Promise.all([
         listPasswordEntries(preferences.passwordStorePath),
         getLastUsedPassword(preferences.lastUsedTtlSeconds),
@@ -92,20 +89,12 @@ export default function Command() {
                   title="View Secrets"
                   icon={Icon.Key}
                   onAction={() => {
-                    if (!locked || preferences.gpgPassphrase) {
-                      return push(
-                        <PasswordOptionsView
-                          password={entry.value}
-                          showOtpFirst={entry.showOtpFirst}
-                          action={preferences.action}
-                          gpgPassword={preferences.gpgPassphrase}
-                        />,
-                      );
-                    }
                     push(
-                      <PasswordEntryForm
-                        entry={entry.value}
+                      <PasswordOptionsView
+                        password={entry.value}
                         showOtpFirst={entry.showOtpFirst}
+                        action={preferences.action}
+                        gpgPassword={preferences.gpgPassphrase}
                       />,
                     );
                   }}
@@ -134,6 +123,10 @@ function PasswordOptionsView({
   const [isLoading, setIsLoading] = useState(true);
   const [options, setOptions] = useState<PasswordOption[]>([]);
   const [error, setError] = useState<string | undefined>();
+  const [retryToken, setRetryToken] = useState(0);
+  const [useSavedPassphrase, setUseSavedPassphrase] = useState(true);
+  const { push } = useNavigation();
+  const effectiveGpgPassword = useSavedPassphrase ? gpgPassword : undefined;
 
   useEffect(() => {
     let disposed = false;
@@ -145,7 +138,7 @@ function PasswordOptionsView({
         const plaintext = await decryptPasswordEntry(
           password,
           preferences,
-          gpgPassword,
+          effectiveGpgPassword,
         );
         const { options: parsed, warnings } = await buildPasswordOptions({
           plaintext,
@@ -184,7 +177,7 @@ function PasswordOptionsView({
     return () => {
       disposed = true;
     };
-  }, [password, preferences, showOtpFirst]);
+  }, [password, preferences, showOtpFirst, effectiveGpgPassword, retryToken]);
 
   return (
     <List
@@ -192,7 +185,41 @@ function PasswordOptionsView({
       searchBarPlaceholder="Select a field to copy/paste"
     >
       {error ? (
-        <List.EmptyView title="Unable to read entry" description={error} />
+        <List.EmptyView
+          title="Unable to read entry"
+          description={error}
+          actions={
+            <ActionPanel>
+              <Action
+                title="Enter GPG Passphrase"
+                icon={Icon.Key}
+                onAction={() => {
+                  push(
+                    <PasswordEntryForm
+                      entry={password}
+                      showOtpFirst={showOtpFirst}
+                    />,
+                  );
+                }}
+              />
+              {gpgPassword && useSavedPassphrase ? (
+                <Action
+                  title="Try System Pinentry"
+                  icon={Icon.Key}
+                  onAction={() => {
+                    setUseSavedPassphrase(false);
+                    setRetryToken((token) => token + 1);
+                  }}
+                />
+              ) : null}
+              <Action
+                title="Retry"
+                icon={Icon.RotateAntiClockwise}
+                onAction={() => setRetryToken((token) => token + 1)}
+              />
+            </ActionPanel>
+          }
+        />
       ) : options.length === 0 ? (
         <List.EmptyView
           title="No fields found"

--- a/extensions/pass/src/pass.tsx
+++ b/extensions/pass/src/pass.tsx
@@ -200,8 +200,7 @@ function PasswordOptionsView({
         />
       ) : (
         options.map((option, index) => {
-          const handleAction = () =>
-            performPasswordAction(password, option, action);
+          const alternateAction = action === "paste" ? "copy" : "paste";
           return (
             <List.Item
               key={`${option.title}-${index}`}
@@ -214,14 +213,14 @@ function PasswordOptionsView({
                     icon={
                       action === "paste" ? Icon.Keyboard : Icon.CopyClipboard
                     }
-                    onAction={handleAction}
+                    onAction={() => performPasswordAction(password, option, action)}
                   />
                   <Action
-                    title={action === "copy" ? "Copy to Clipboard" : "Paste"}
+                    title={alternateAction === "copy" ? "Copy to Clipboard" : "Paste"}
                     icon={
-                      action === "copy" ? Icon.CopyClipboard : Icon.Keyboard
+                      alternateAction === "copy" ? Icon.CopyClipboard : Icon.Keyboard
                     }
-                    onAction={handleAction}
+                    onAction={() => performPasswordAction(password, option, alternateAction)}
                   />
                 </ActionPanel>
               }

--- a/extensions/pass/src/preferences.ts
+++ b/extensions/pass/src/preferences.ts
@@ -1,6 +1,6 @@
 import { getPreferenceValues } from "@vicinae/api";
 import { resolveAbsolutePath } from "@/utils/path";
-import { Schema } from "@/types"
+import { Schema } from "@/types";
 
 type RawPreferences = {
   passwordStorePath?: string;
@@ -24,7 +24,7 @@ export type Preferences = {
 
 export function getPreferences(): Preferences {
   const raw = getPreferenceValues<RawPreferences>();
-  const path = raw.passwordStorePath || "~/.password-store";
+  const path = raw.passwordStorePath || process.env.PASSWORD_STORE_DIR || "~/.password-store";
   return {
     passwordStorePath: resolveAbsolutePath(path),
     gpgPassphrase: sanitizeString(raw.gpgPassphrase),
@@ -32,14 +32,20 @@ export function getPreferences(): Preferences {
     otpAfterPassword: raw.otpAfterPassword ?? true,
     lastUsedTtlSeconds: parsePositiveInt(raw.lastUsedTtl, 120),
     action: raw.action || "paste",
-    schema: parseJson(raw.fileSchema)
+    schema: parseJson(raw.fileSchema),
   };
 }
 
-function parseJson(value?: string) {
+function parseJson(value?: string): Schema | null {
   const jsonString = sanitizeString(value);
   if (jsonString == undefined) return null;
-  return JSON.parse(jsonString);
+
+  try {
+    return JSON.parse(jsonString) as Schema;
+  } catch (error) {
+    console.error("Failed to parse file schema preference:", error);
+    return null;
+  }
 }
 
 function sanitizeString(value?: string): string | undefined {

--- a/extensions/pass/src/services/command.ts
+++ b/extensions/pass/src/services/command.ts
@@ -27,25 +27,36 @@ export async function runCommand(command: string, args: string[], preferences: P
     return stdout;
   } catch (error) {
     const err = error as NodeJS.ErrnoException & { stderr?: string };
+    const stderr = typeof err.stderr === "string" ? err.stderr : undefined;
+    const details = stderr?.trim() || err.message || String(err.code ?? "unknown error");
     throw new CommandError(
-      `Failed to run ${command}`,
+      `Failed to run ${command}: ${details}`,
       err.code,
-      typeof err.stderr === "string" ? err.stderr : undefined,
+      stderr,
     );
   }
 }
 
 function buildEnv(additionalPath?: string): NodeJS.ProcessEnv {
-  const extras = additionalPath
-    ?.split(":")
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-
-  const currentPath = process.env.PATH ?? "";
-  const updatedPath = extras && extras.length > 0 ? `${currentPath}:${extras.join(":")}` : currentPath;
+  const platformDefaults = process.platform === "darwin"
+    ? ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin", "/usr/local/MacGPG2/bin"]
+    : [];
+  const pathEntries = [
+    ...splitPath(additionalPath),
+    ...platformDefaults,
+    ...splitPath(process.env.PATH),
+  ];
+  const updatedPath = Array.from(new Set(pathEntries)).join(":");
 
   return {
     ...process.env,
     PATH: updatedPath,
   };
+}
+
+function splitPath(value?: string): string[] {
+  return value
+    ?.split(":")
+    .map((entry) => entry.trim())
+    .filter(Boolean) ?? [];
 }

--- a/extensions/pass/src/services/command.ts
+++ b/extensions/pass/src/services/command.ts
@@ -1,50 +1,112 @@
 import { execFile } from "child_process";
-import { promisify } from "util";
+import os from "os";
+import path from "path";
 import { Preferences } from "@/preferences";
 
-const execFileAsync = promisify(execFile);
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MAX_BUFFER_BYTES = 1024 * 1024;
+
+type RunCommandOptions = {
+  input?: string;
+  timeoutMs?: number;
+};
 
 export class CommandError extends Error {
   constructor(
     message: string,
     public readonly code?: string | number,
     public readonly stderr?: string,
+    public readonly signal?: NodeJS.Signals,
   ) {
     super(message);
     this.name = "CommandError";
   }
 }
 
-export async function runCommand(command: string, args: string[], preferences: Preferences): Promise<string> {
+export async function runCommand(
+  command: string,
+  args: string[],
+  preferences: Preferences,
+  options: RunCommandOptions = {},
+): Promise<string> {
   const env = buildEnv(preferences.additionalPath);
 
-  try {
-    const { stdout } = await execFileAsync(command, args, {
-      env,
-      maxBuffer: 1024 * 1024,
-      encoding: "utf-8",
-    });
-    return stdout;
-  } catch (error) {
-    const err = error as NodeJS.ErrnoException & { stderr?: string };
-    const stderr = typeof err.stderr === "string" ? err.stderr : undefined;
-    const details = stderr?.trim() || err.message || String(err.code ?? "unknown error");
-    throw new CommandError(
-      `Failed to run ${command}: ${details}`,
-      err.code,
-      stderr,
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      command,
+      args,
+      {
+        env,
+        maxBuffer: MAX_BUFFER_BYTES,
+        encoding: "utf-8",
+        timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        const stderrText = bufferToString(stderr);
+        if (error) {
+          reject(toCommandError(command, error, stderrText, env.PATH));
+          return;
+        }
+        resolve(bufferToString(stdout));
+      },
     );
+
+    child.stdin?.on("error", () => undefined);
+    if (options.input === undefined) {
+      child.stdin?.end();
+    } else {
+      child.stdin?.end(options.input);
+    }
+  });
+}
+
+function toCommandError(
+  command: string,
+  error: Error & NodeJS.ErrnoException & { killed?: boolean; signal?: NodeJS.Signals },
+  stderr?: string,
+  effectivePath?: string,
+): CommandError {
+  let details = stderr?.trim() || error.message || String(error.code ?? "unknown error");
+
+  if (error.code === "ENOENT") {
+    details = `command not found in PATH. Set Additional PATH Entries in preferences if needed. Effective PATH: ${effectivePath || "(empty)"}`;
+  } else if (error.killed || error.signal) {
+    details = `timed out or was interrupted (${error.signal ?? "no signal"})`;
   }
+
+  return new CommandError(
+    `Failed to run ${command}: ${details}`,
+    error.code,
+    stderr,
+    error.signal,
+  );
 }
 
 function buildEnv(additionalPath?: string): NodeJS.ProcessEnv {
+  const user = process.env.USER || os.userInfo().username;
+  const home = os.homedir();
   const platformDefaults = process.platform === "darwin"
-    ? ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin", "/usr/local/MacGPG2/bin"]
-    : [];
+    ? [
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/opt/local/bin",
+        "/usr/local/MacGPG2/bin",
+      ]
+    : ["/usr/local/bin"];
+  const profileDefaults = [
+    path.join(home, ".nix-profile", "bin"),
+    `/etc/profiles/per-user/${user}/bin`,
+    "/nix/var/nix/profiles/default/bin",
+    "/run/current-system/sw/bin",
+  ];
+  const systemDefaults = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"];
   const pathEntries = [
     ...splitPath(additionalPath),
     ...platformDefaults,
+    ...profileDefaults,
     ...splitPath(process.env.PATH),
+    ...systemDefaults,
   ];
   const updatedPath = Array.from(new Set(pathEntries)).join(":");
 
@@ -57,6 +119,16 @@ function buildEnv(additionalPath?: string): NodeJS.ProcessEnv {
 function splitPath(value?: string): string[] {
   return value
     ?.split(":")
-    .map((entry) => entry.trim())
+    .map((entry) => expandHome(entry.trim()))
     .filter(Boolean) ?? [];
+}
+
+function expandHome(entry: string): string {
+  if (entry === "~") return os.homedir();
+  if (entry.startsWith("~/")) return path.join(os.homedir(), entry.slice(2));
+  return entry;
+}
+
+function bufferToString(value: string | Buffer): string {
+  return typeof value === "string" ? value : value.toString("utf-8");
 }

--- a/extensions/pass/src/services/passctl.ts
+++ b/extensions/pass/src/services/passctl.ts
@@ -1,20 +1,9 @@
 import { Stats, promises as fs } from "fs";
 import path from "path";
 import { Preferences } from "@/preferences";
-import { runCommand } from "@/services/command";
+import { CommandError, runCommand } from "@/services/command";
 
-export async function isGpgUnlocked(preferences: Preferences) {
-  try {
-    await runCommand(
-      "sh",
-      ["-c", "echo test | gpg --clearsign --batch --yes --pinentry-mode=error"],
-      preferences,
-    );
-    return false;
-  } catch {
-    return true;
-  }
-}
+const GPG_TIMEOUT_MS = 60_000;
 
 export async function listPasswordEntries(
   storePath: string,
@@ -39,14 +28,71 @@ export async function decryptPasswordEntry(
     throw new Error(`Entry "${entry}" was not found in the password store`);
   }
 
-  const args = ["--batch", "--yes"];
-  if (gpgPassword) {
-    args.push("--pinentry-mode=loopback", "--passphrase", gpgPassword);
-  }
-  args.push("-d", filePath);
+  const usesLoopback = Boolean(gpgPassword);
+  const args = buildDecryptArgs(filePath, usesLoopback);
 
-  const stdout = await runCommand("gpg", args, preferences);
-  return stdout.replace(/\r\n/g, "\n");
+  try {
+    const stdout = await runCommand("gpg", args, preferences, {
+      input: gpgPassword ? `${gpgPassword}\n` : undefined,
+      timeoutMs: GPG_TIMEOUT_MS,
+    });
+    return stdout.replace(/\r\n/g, "\n");
+  } catch (error) {
+    if (error instanceof CommandError) {
+      throw new Error(formatGpgError(error, usesLoopback));
+    }
+    throw error;
+  }
+}
+
+function buildDecryptArgs(filePath: string, usesLoopback: boolean): string[] {
+  const args = ["--quiet", "--yes"];
+
+  if (usesLoopback) {
+    args.push(
+      "--batch",
+      "--pinentry-mode",
+      "loopback",
+      "--passphrase-fd",
+      "0",
+    );
+  }
+
+  args.push("--decrypt", "--output", "-", filePath);
+  return args;
+}
+
+function formatGpgError(error: CommandError, usesLoopback: boolean): string {
+  const raw = `${error.stderr ?? ""}\n${error.message}`.toLowerCase();
+
+  if (error.code === "ENOENT") {
+    return "gpg was not found. Install GnuPG or add its directory to the Pass extension's Additional PATH Entries preference.";
+  }
+
+  if (raw.includes("timed out") || raw.includes("interrupted")) {
+    return "GPG did not finish. A pinentry prompt may be hidden or unavailable; unlock your key in a terminal or enter the GPG passphrase in the extension.";
+  }
+
+  if (usesLoopback && /bad passphrase|bad session key|decryption failed.*bad/.test(raw)) {
+    return "Incorrect GPG passphrase.";
+  }
+
+  if (
+    usesLoopback &&
+    (/setting pinentry mode.*failed|not supported|not allowed|allow-loopback|forbidden/.test(raw))
+  ) {
+    return "GPG loopback pinentry is not enabled. Add 'allow-loopback-pinentry' to ~/.gnupg/gpg-agent.conf, restart gpg-agent, or clear the saved passphrase and use your system pinentry.";
+  }
+
+  if (/no pinentry|pinentry|inappropriate ioctl|can't get input|batchmode/.test(raw)) {
+    return "GPG needs a passphrase but no pinentry prompt is available. Configure pinentry for gpg-agent or enter the GPG passphrase in the extension.";
+  }
+
+  if (/no secret key|secret key not available|decryption failed.*secret key/.test(raw)) {
+    return "No matching GPG secret key was found for this pass entry. Import or trust the key used by the password store.";
+  }
+
+  return error.message;
 }
 
 async function walkStore(root: string, relative = ""): Promise<string[]> {

--- a/extensions/pass/src/utils/password.ts
+++ b/extensions/pass/src/utils/password.ts
@@ -78,14 +78,22 @@ export async function buildPasswordOptions({
       const pref = preferences.schema![index];
       if (data != "" && pref != undefined) {
         if (pref.type == "otp" && data.startsWith("otpauth")) {
-          const code = await deriveOtpCode(data, preferences);
-          const index = prioritizeOtp ? 0 : options.length;
+          try {
+            const code = await deriveOtpCode(data, preferences);
+            const index = prioritizeOtp ? 0 : options.length;
 
-          options.splice(index, 0, ({
-            title: pref.key,
-            value: code,
-            type: pref.type
-          }));
+            options.splice(index, 0, ({
+              title: pref.key,
+              value: code,
+              type: pref.type
+            }));
+          } catch (error) {
+            const message =
+              error instanceof OtpError
+                ? error.message
+                : "Failed to generate OTP code";
+            warnings.push(message);
+          }
         }
         else {
           options.push({


### PR DESCRIPTION
## Summary

   Fixes macOS runtime issues in the `pass` extension.

   ## Changes

   - Prepend custom `additionalPath` entries instead of appending them.
   - Add common macOS binary paths for Homebrew/MacPorts/MacGPG:
     - `/opt/homebrew/bin`
     - `/usr/local/bin`
     - `/opt/local/bin`
     - `/usr/local/MacGPG2/bin`
   - Surface `gpg`/command stderr in user-facing errors.
   - Support `PASSWORD_STORE_DIR` as fallback for password store location.
   - Prevent invalid `fileSchema` JSON from crashing the extension.
   - Prevent OTP generation errors in schema mode from crashing the secrets view.
   - Fix alternate Copy/Paste action so it actually uses the opposite action.
   - Update README with macOS GPG/pinentry/oathtool troubleshooting.