### PR TITLE
Remember previously selected Iconify icon set

### DIFF
--- a/extensions/iconify/src/iconify-utils.ts
+++ b/extensions/iconify/src/iconify-utils.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import {
 	Clipboard,
 	Color,
+  LocalStorage,
 	environment,
 	getPreferenceValues,
 	Icon,
@@ -35,6 +36,8 @@ export const ACTION_ORDER: PrimaryAction[] = [
 export const DEFAULT_COLUMNS = 8;
 export const DEFAULT_ITEMS_PER_PAGE = 800;
 
+export const PREVIOUS_SET_ID_KEY = "iconify.previousSetId";
+
 export const getPreferences = () => getPreferenceValues<Preferences>();
 
 export const getPrimaryAction = () =>
@@ -48,6 +51,14 @@ export const getColumnsPreference = () => {
 export const getItemsPerPagePreference = () => {
 	const value = Number.parseInt(getPreferences().itemsPerPage ?? "", 10);
 	return Number.isFinite(value) && value > 0 ? value : DEFAULT_ITEMS_PER_PAGE;
+};
+
+export const setPreviousSetId = async (setId: string) => {
+  await LocalStorage.setItem(PREVIOUS_SET_ID_KEY, setId);
+};
+
+export const getPreviousSetId = async () => {
+  return await LocalStorage.getItem<string>(PREVIOUS_SET_ID_KEY);
 };
 
 export const getIconColor = (launchContext?: { hex?: string }) => {

--- a/extensions/iconify/src/view-icons.tsx
+++ b/extensions/iconify/src/view-icons.tsx
@@ -14,6 +14,8 @@ import {
 	getColumnsPreference,
 	getIconColor,
 	getItemsPerPagePreference,
+  getPreviousSetId,
+  setPreviousSetId,
 	iconToImage,
 	toDataUri,
 	toSvg,
@@ -107,11 +109,18 @@ export default function ViewIconsCommand({
 	const itemsPerPage = getItemsPerPagePreference();
 	const iconColor = getIconColor(launchContext);
 
-	useEffect(() => {
-		if (!activeSetId && sets.length > 0) {
-			setActiveSetId(sets[0].id);
-		}
-	}, [activeSetId, sets]);
+  useEffect(() => {
+    const initializeActiveSetId = async () => {
+      const previousSetId = await getPreviousSetId();
+      if (previousSetId && sets.some((set) => set.id === previousSetId)) {
+        setActiveSetId(previousSetId);
+      } else if (sets.length > 0) {
+        setActiveSetId(sets[0].id);
+      }
+    };
+
+    initializeActiveSetId();
+  }, [activeSetId, sets]);
 
 	const activeSet = sets.find((set) => set.id === activeSetId) ?? sets[0];
 	const {
@@ -167,6 +176,7 @@ export default function ViewIconsCommand({
 					value={activeSet?.id}
 					onChange={(value) => {
 						setActiveSetId(value);
+            setPreviousSetId(value);
 						setPage(0);
 					}}
 				>


### PR DESCRIPTION
Previously, I had to select my desired icon set each time I ran the `View Icons` command. This pull requests adds a very simple store/restore logic using local storage. 