### PR TITLE
fix(prompt-deck): broken Quicklink deeplinks on store installs

### DIFF
--- a/extensions/prompt-deck/src/lib/quicklink.ts
+++ b/extensions/prompt-deck/src/lib/quicklink.ts
@@ -1,4 +1,5 @@
 import { environment, Icon } from "@vicinae/api";
+import { basename } from "node:path";
 import { RUN_COMMAND } from "./constants";
 import type { LlmShortcut } from "./types";
 
@@ -20,12 +21,28 @@ export function buildPromptQuicklink(shortcut: LlmShortcut) {
 }
 
 /**
+ * Resolves the extension id Vicinae routes deeplinks by.
+ *
+ * `environment.extensionName` is the manifest `name` ("prompt-deck"), but the
+ * launcher keys entrypoints on the *install* id, which the store namespaces to
+ * "store.vicinae.prompt-deck". The support directory is `<data>/support/<id>`,
+ * so its name recovers the id for store and development installs alike. The
+ * manifest name is a last resort that keeps the link well-formed.
+ */
+function resolveExtensionId(): string {
+  const fromSupport = environment.supportPath && basename(environment.supportPath);
+  if (fromSupport) return fromSupport;
+
+  return environment.extensionName || "prompt-deck";
+}
+
+/**
  * Builds the Vicinae deeplink used by prompt Quicklinks. Author and extension
- * name come from the runtime environment so they track the manifest.
+ * id come from the runtime environment so they track the actual install.
  */
 export function buildShortcutDeeplink(shortcut: LlmShortcut): string {
   const author = environment.ownerOrAuthorName || "tadassuksteris";
-  const extension = environment.extensionName || "prompt-deck";
+  const extension = resolveExtensionId();
   const args = encodeURIComponent(JSON.stringify({ shortcutId: shortcut.id }));
   return `vicinae://launch/@${author}/${extension}/${RUN_COMMAND}?arguments=${args}`;
 }


### PR DESCRIPTION
Every Quicklink the extension created was broken for anyone who installed it
from the store. The deeplinks were built from the manifest name, `prompt-deck`,
but store installs are keyed by install id — `store.vicinae.prompt-deck` — so
nothing resolved.

It now comes from `supportPath` instead. Quicklinks already created still need recreating.