### PR TITLE
feat(vscode-recents): add support for code oss

### DIFF
--- a/extensions/vscode-recents/package.json
+++ b/extensions/vscode-recents/package.json
@@ -43,6 +43,10 @@
                     "value": "Code"
                 },
                 {
+                    "title": "Code - OSS",
+                    "value": "Code - OSS"
+                },
+                {
                     "title": "Antigravity",
                     "value": "Antigravity"
                 },

--- a/extensions/vscode-recents/src/constants.ts
+++ b/extensions/vscode-recents/src/constants.ts
@@ -9,6 +9,7 @@ export const WORKSPACE_EXTENSION = ".code-workspace";
 // Note: needs to match Preferences.vscodeFlavour values
 export const VSCODE_EXECUTABLES: Record<string, string> = {
     Code: "code",
+    "Code - OSS": "code",
     Cursor: "cursor",
     VSCodium: "codium",
     Antigravity: "antigravity",
@@ -18,6 +19,7 @@ export const VSCODE_EXECUTABLES: Record<string, string> = {
 
 const VSCODE_SHARED_STORAGE_DIRS: Record<string, string> = {
     "Code": ".vscode-shared",
+    "Code - OSS": ".vscode-oss-shared",
     "Cursor": ".cursor-shared",
     "VSCodium": ".vscode-oss-shared",
     "Antigravity": ".antigravity-shared",

--- a/extensions/vscode-recents/src/constants.ts
+++ b/extensions/vscode-recents/src/constants.ts
@@ -1,3 +1,5 @@
+import { VSCodeFlavour } from "./types";
+
 export const RECENT_PROJECTS_QUERY = "SELECT key, value FROM ItemTable WHERE key LIKE 'history.recentlyOpenedPathsList'";
 
 export const SQL_WASM_PATH = "assets/sql-wasm.wasm";
@@ -6,43 +8,43 @@ export const FILE_URI_SCHEME = "file://";
 
 export const WORKSPACE_EXTENSION = ".code-workspace";
 
-// Note: needs to match Preferences.vscodeFlavour values
-export const VSCODE_EXECUTABLES: Record<string, string> = {
-    Code: "code",
-    "Code - OSS": "code",
-    Cursor: "cursor",
-    VSCodium: "codium",
-    Antigravity: "antigravity",
-    Windsurf: "windsurf",
-    "Code - Insiders": "code-insiders",
+export const VSCODE_EXECUTABLES: Record<VSCodeFlavour, string> = {
+    [VSCodeFlavour.Code]: "code",
+    [VSCodeFlavour.CodeOSS]: "code",
+    [VSCodeFlavour.Cursor]: "cursor",
+    [VSCodeFlavour.VSCodium]: "codium",
+    [VSCodeFlavour.Antigravity]: "antigravity",
+    [VSCodeFlavour.Windsurf]: "windsurf",
+    [VSCodeFlavour.CodeInsiders]: "code-insiders",
 };
 
-const VSCODE_SHARED_STORAGE_DIRS: Record<string, string> = {
-    "Code": ".vscode-shared",
-    "Code - OSS": ".vscode-oss-shared",
-    "Cursor": ".cursor-shared",
-    "VSCodium": ".vscode-oss-shared",
-    "Antigravity": ".antigravity-shared",
-    "Code - Insiders": ".vscode-insiders-shared",
+const VSCODE_SHARED_STORAGE_DIRS: Record<VSCodeFlavour, string> = {
+    [VSCodeFlavour.Code]: ".vscode-shared",
+    [VSCodeFlavour.CodeOSS]: ".vscode-oss-shared",
+    [VSCodeFlavour.Cursor]: ".cursor-shared",
+    [VSCodeFlavour.VSCodium]: ".vscode-oss-shared",
+    [VSCodeFlavour.Antigravity]: ".antigravity-shared",
+    [VSCodeFlavour.Windsurf]: ".vscode-shared",
+    [VSCodeFlavour.CodeInsiders]: ".vscode-insiders-shared",
 };
 
 export const VSCODE_SHARED_STATE_PATHS = {
-    linux: (home: string, flavour: string) => {
-        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour] || ".vscode-shared";
+    linux: (home: string, flavour: VSCodeFlavour) => {
+        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour];
         return `${home}/${sharedDir}/sharedStorage/state.vscdb`;
     },
-    win32: (home: string, flavour: string) => {
-        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour] || ".vscode-shared";
+    win32: (home: string, flavour: VSCodeFlavour) => {
+        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour];
         return `${home}/AppData/Roaming/${sharedDir}/sharedStorage/state.vscdb`;
     },
-    darwin: (home: string, flavour: string) => {
-        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour] || ".vscode-shared";
+    darwin: (home: string, flavour: VSCodeFlavour) => {
+        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour];
         return `${home}/Library/Application Support/${sharedDir}/sharedStorage/state.vscdb`;
     },
 } as const;
 
 export const VSCODE_STATE_PATHS = {
-    linux: (home: string, flavour: string) => `${home}/.config/${flavour}/User/globalStorage/state.vscdb`,
-    win32: (home: string, flavour: string) => `${home}/AppData/Roaming/${flavour}/User/globalStorage/state.vscdb`,
-    darwin: (home: string, flavour: string) => `${home}/Library/Application Support/${flavour}/User/globalStorage/state.vscdb`,
+    linux: (home: string, flavour: VSCodeFlavour) => `${home}/.config/${flavour}/User/globalStorage/state.vscdb`,
+    win32: (home: string, flavour: VSCodeFlavour) => `${home}/AppData/Roaming/${flavour}/User/globalStorage/state.vscdb`,
+    darwin: (home: string, flavour: VSCodeFlavour) => `${home}/Library/Application Support/${flavour}/User/globalStorage/state.vscdb`,
 } as const;

--- a/extensions/vscode-recents/src/types.ts
+++ b/extensions/vscode-recents/src/types.ts
@@ -39,6 +39,7 @@ export interface VSCodeRecentData {
 
 export enum VSCodeFlavour {
     Code = "Code",
+    CodeOSS = "Code - OSS",
     Cursor = "Cursor",
     VSCodium = "VSCodium",
     CodeInsiders = "Code - Insiders",


### PR DESCRIPTION
This PR adds support for Code OSS (Arch's open source release of visual studio code).

Previously the extension was half working when selecting `VSCodium` as a flavor because they share the same `VSCODE_SHARED_STORAGE_DIR` but the binary for Code OSS is `code` and not `codium` so listing the projects worked but not opening them.

I also propose a small refactor where I replaced the plain `string` types in favor of the `VSCodeFlavor` enum to avoid missing entries in the constants (`windsurf` was not present in `VSCODE_SHARED_STORAGE_DIRS` for exemple).