### PR TITLE
fix(vscode-recents): make it work on macOS

### DIFF
--- a/extensions/vscode-recents/package.json
+++ b/extensions/vscode-recents/package.json
@@ -5,7 +5,7 @@
     "description": "Open VSCode and compatible editors recent projects",
     "license": "MIT",
     "platforms": ["Linux", "macOS"],
-    "contributors": [],
+    "contributors": ["tonicastillo"],
     "pastContributors": [],
     "author": "ShyAssassin",
     "icon": "extension_icon.png",

--- a/extensions/vscode-recents/src/constants.ts
+++ b/extensions/vscode-recents/src/constants.ts
@@ -28,23 +28,42 @@ const VSCODE_SHARED_STORAGE_DIRS: Record<VSCodeFlavour, string> = {
     [VSCodeFlavour.CodeInsiders]: ".vscode-insiders-shared",
 };
 
-export const VSCODE_SHARED_STATE_PATHS = {
-    linux: (home: string, flavour: VSCodeFlavour) => {
-        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour];
-        return `${home}/${sharedDir}/sharedStorage/state.vscdb`;
-    },
-    win32: (home: string, flavour: VSCodeFlavour) => {
-        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour];
-        return `${home}/AppData/Roaming/${sharedDir}/sharedStorage/state.vscdb`;
-    },
-    darwin: (home: string, flavour: VSCodeFlavour) => {
-        const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour];
-        return `${home}/Library/Application Support/${sharedDir}/sharedStorage/state.vscdb`;
-    },
-} as const;
+// FIX(macOS/Windows): the shared storage directory hangs directly off the user's
+// home directory on EVERY platform, not under the per-platform application data
+// directory. VS Code resolves it as:
+//     get appSharedDataHome() { ... return joinPath(this.userHome, this.productService.sharedDataFolderName) }
+// (vs/platform/environment/node/environmentService.ts), and `userHome` is plain
+// `os.homedir()`. The previous per-platform table only produced the right path on
+// Linux; on macOS it pointed at "~/Library/Application Support/.vscode-shared",
+// which never exists, so the lookup silently fell back to the legacy DB - a file
+// that still exists but no longer holds `history.recentlyOpenedPathsList`,
+// yielding an empty list with no error.
+export const getSharedStateDBPath = (home: string, flavour: VSCodeFlavour): string => {
+    const sharedDir = VSCODE_SHARED_STORAGE_DIRS[flavour];
+    return `${home}/${sharedDir}/sharedStorage/state.vscdb`;
+};
 
 export const VSCODE_STATE_PATHS = {
     linux: (home: string, flavour: VSCodeFlavour) => `${home}/.config/${flavour}/User/globalStorage/state.vscdb`,
     win32: (home: string, flavour: VSCodeFlavour) => `${home}/AppData/Roaming/${flavour}/User/globalStorage/state.vscdb`,
     darwin: (home: string, flavour: VSCodeFlavour) => `${home}/Library/Application Support/${flavour}/User/globalStorage/state.vscdb`,
 } as const;
+
+// FIX(macOS): the Vicinae server is started by LaunchServices, so extensions inherit
+// a bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin`. The `code` shim lives in /usr/local/bin
+// (and Homebrew casks use /opt/homebrew/bin), neither of which is on that PATH, so
+// `command -v <executable>` always failed and the extension only ever showed
+// "Command not found". These are searched in addition to the inherited PATH.
+export const MACOS_EXTRA_PATHS = ["/usr/local/bin", "/opt/homebrew/bin"];
+
+// Last-resort lookup: the CLI shipped inside the application bundle itself, which
+// exists even when the user never ran "Shell Command: Install 'code' command in PATH".
+export const MACOS_APP_BUNDLES: Record<VSCodeFlavour, string> = {
+    [VSCodeFlavour.Code]: "Visual Studio Code",
+    [VSCodeFlavour.CodeOSS]: "Code - OSS",
+    [VSCodeFlavour.Cursor]: "Cursor",
+    [VSCodeFlavour.VSCodium]: "VSCodium",
+    [VSCodeFlavour.Antigravity]: "Antigravity",
+    [VSCodeFlavour.Windsurf]: "Windsurf",
+    [VSCodeFlavour.CodeInsiders]: "Visual Studio Code - Insiders",
+};

--- a/extensions/vscode-recents/src/helpers.ts
+++ b/extensions/vscode-recents/src/helpers.ts
@@ -2,31 +2,26 @@ import path from "path";
 import { homedir } from "os";
 import { existsSync } from "fs";
 import { getPreferenceValues } from "@vicinae/api";
-import { VSCODE_SHARED_STATE_PATHS, VSCODE_STATE_PATHS } from "./constants";
+import { getSharedStateDBPath, VSCODE_STATE_PATHS, WORKSPACE_EXTENSION } from "./constants";
 import { type Preferences, ProjectEnvironment, ProjectType, type RecentProject } from "./types";
 
-export function getVSCodeStateDBPath(): string {
+export const getVSCodeStateDBPath = (): string => {
     const home = homedir();
     const { vscodeFlavour } = getPreferenceValues<Preferences>();
     const platform = process.platform as keyof typeof VSCODE_STATE_PATHS;
 
-    // Try the new shared storage path first (VS Code 1.118+)
-    // Each flavor has its own shared storage directory
+    // Try the new shared storage path first (VS Code 1.118+).
+    // Each flavour has its own shared storage directory, and on every platform it
+    // hangs directly off the home directory - see getSharedStateDBPath().
+    const sharedPath = getSharedStateDBPath(home, vscodeFlavour);
+
+    if (existsSync(sharedPath)) {
+        console.log("[DEBUG] Using shared storage path:", sharedPath);
+        return sharedPath;
+    }
+
+    // Fall back to legacy per-flavour path (pre VS Code 1.118)
     let dbPath: string;
-    if (platform in VSCODE_SHARED_STATE_PATHS) {
-        dbPath = VSCODE_SHARED_STATE_PATHS[platform](home, vscodeFlavour);
-    } else {
-        // Default to Linux path for unsupported platforms
-        dbPath = VSCODE_SHARED_STATE_PATHS.linux(home, vscodeFlavour);
-    }
-
-    // If the shared storage path exists, use it
-    if (existsSync(dbPath)) {
-        console.log("[DEBUG] Using shared storage path:", dbPath);
-        return dbPath;
-    }
-
-    // Fall back to legacy per-flavor path (pre VS Code 1.118)
     if (platform in VSCODE_STATE_PATHS) {
         dbPath = VSCODE_STATE_PATHS[platform](home, vscodeFlavour);
     } else {
@@ -36,21 +31,33 @@ export function getVSCodeStateDBPath(): string {
 
     if (!existsSync(dbPath)) {
         throw new Error(
-            `Database for ${vscodeFlavour} not found at: ${dbPath}. Make sure it's installed and that you have opened it at least once.`,
+            `Database for ${vscodeFlavour} not found at ${sharedPath} nor ${dbPath}. Make sure it's installed and that you have opened it at least once.`,
         );
     }
 
-    console.log("[DEBUG] Using legacy flavor-specific path:", dbPath);
+    console.log("[DEBUG] Using legacy flavour-specific path:", dbPath);
     return dbPath;
-}
+};
 
 export function decodeFileUri(uri: string): string {
     return decodeURIComponent(uri.replace(/^file:\/\//, ""));
 }
 
-export function getProjectLabel(projectType: ProjectType, projectPath: string, projectLabel: string | undefined = undefined): string {
-    return path.basename(projectLabel ?? projectPath) + (projectType === ProjectType.Workspace ? ".code-workspace" : "");
-}
+export const getProjectLabel = (
+    projectType: ProjectType,
+    projectPath: string,
+    projectLabel: string | undefined = undefined,
+): string => {
+    const name = path.basename(projectLabel ?? projectPath);
+
+    // FIX: workspace paths already end in ".code-workspace", so appending it
+    // unconditionally produced labels like "MyProject.code-workspace.code-workspace".
+    if (projectType !== ProjectType.Workspace || name.endsWith(WORKSPACE_EXTENSION)) {
+        return name;
+    }
+
+    return name + WORKSPACE_EXTENSION;
+};
 
 export function sortProjectsByLastOpenedOrIndex(projects: RecentProject[]): RecentProject[] {
     return [...projects].sort((a, b) => {

--- a/extensions/vscode-recents/src/util/vscode.ts
+++ b/extensions/vscode-recents/src/util/vscode.ts
@@ -1,12 +1,14 @@
+import { homedir } from "os";
+import { existsSync } from "fs";
 import { promisify } from "util";
 import { exec } from "child_process";
 import { type Preferences, ProjectType, type RecentProject, WindowPreference } from "../types";
-import { VSCODE_EXECUTABLES } from "../constants";
+import { MACOS_APP_BUNDLES, MACOS_EXTRA_PATHS, VSCODE_EXECUTABLES } from "../constants";
 import { getPreferenceValues, showToast, Toast } from "@vicinae/api";
 
 const execAsync = promisify(exec);
 
-function getVSCodeExecutable(): string {
+const getVSCodeExecutable = (): string => {
     const { vscodeFlavour } = getPreferenceValues<Preferences>();
     const executable = VSCODE_EXECUTABLES[vscodeFlavour];
 
@@ -15,34 +17,104 @@ function getVSCodeExecutable(): string {
     }
 
     return executable;
-}
+};
 
-async function isExecutableAvailable(executable: string): Promise<boolean> {
-    try {
-        await execAsync(`command -v ${executable}`);
-        return true;
-    } catch {
-        return false;
+/**
+ * FIX(macOS): the Vicinae server is launched by LaunchServices rather than from a
+ * login shell, so extensions inherit `PATH=/usr/bin:/bin:/usr/sbin:/sbin`. The
+ * `code` shim installed by "Shell Command: Install 'code' command in PATH" lives in
+ * /usr/local/bin, and Homebrew casks use /opt/homebrew/bin - neither is on that
+ * PATH. `command -v code` therefore always failed and the extension could never
+ * open anything, only ever showing the "Command not found" toast.
+ */
+const getSearchPath = (): string => {
+    const inherited = process.env.PATH ?? "";
+
+    if (process.platform !== "darwin") {
+        return inherited;
     }
-}
 
-export async function openProjectInVSCode(project: RecentProject): Promise<void> {
-    const { vscodeFlavour, windowPreference } = getPreferenceValues<Preferences>();
+    const entries = inherited.split(":").filter(Boolean);
+    const extra = [...MACOS_EXTRA_PATHS, `${homedir()}/.local/bin`].filter((dir) => !entries.includes(dir));
+
+    return [...entries, ...extra].join(":");
+};
+
+/**
+ * Last resort on macOS: the CLI that ships inside the application bundle. It is
+ * present even when the user never installed the shell command.
+ */
+const getBundledExecutable = (): string | null => {
+    if (process.platform !== "darwin") {
+        return null;
+    }
+
+    const { vscodeFlavour } = getPreferenceValues<Preferences>();
+    const appName = MACOS_APP_BUNDLES[vscodeFlavour];
+
+    if (!appName) {
+        return null;
+    }
+
+    const executable = VSCODE_EXECUTABLES[vscodeFlavour];
+    const candidates = [
+        `/Applications/${appName}.app/Contents/Resources/app/bin/${executable}`,
+        `${homedir()}/Applications/${appName}.app/Contents/Resources/app/bin/${executable}`,
+    ];
+
+    return candidates.find((candidate) => existsSync(candidate)) ?? null;
+};
+
+const resolveExecutable = async (searchPath: string): Promise<string | null> => {
     const executable = getVSCodeExecutable();
 
     try {
-        const isAvailable = await isExecutableAvailable(executable);
+        const { stdout } = await execAsync(`command -v ${executable}`, { env: { ...process.env, PATH: searchPath } });
+        const resolved = stdout.trim();
 
-        if (!isAvailable) {
+        if (resolved) {
+            return resolved;
+        }
+    } catch {
+        // Not on PATH; fall through to the bundled CLI.
+    }
+
+    return getBundledExecutable();
+};
+
+/**
+ * FIX: `project.path` is a decoded filesystem path (decodeFileUri strips the
+ * `file://` prefix and percent-decodes it), but it was being passed straight to
+ * `--folder-uri`, which parses its argument as a URI. A path containing `#` or `?`
+ * therefore loses everything from that character onwards, and the editor silently
+ * opens the truncated path instead. Local paths are now re-encoded into a proper
+ * file URI; remote paths already are URIs and are passed through untouched.
+ */
+const toFolderUri = (projectPath: string): string => {
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(projectPath)) {
+        return projectPath;
+    }
+
+    return new URL(`file://${projectPath.split("/").map(encodeURIComponent).join("/")}`).href;
+};
+
+export const openProjectInVSCode = async (project: RecentProject): Promise<void> => {
+    const { vscodeFlavour, windowPreference } = getPreferenceValues<Preferences>();
+    const searchPath = getSearchPath();
+
+    try {
+        const executable = await resolveExecutable(searchPath);
+
+        if (!executable) {
             showToast({
                 title: "Command not found",
                 style: Toast.Style.Failure,
-                message: `Make sure the '${executable}' command is available in your PATH.`,
+                message: `Could not locate the '${getVSCodeExecutable()}' command for ${vscodeFlavour}.`,
             });
             return;
         }
 
-        let command = `${executable}`;
+        let command = JSON.stringify(executable);
 
         if (windowPreference === WindowPreference.NewWindow) {
             command += " --new-window";
@@ -50,14 +122,16 @@ export async function openProjectInVSCode(project: RecentProject): Promise<void>
             command += " --reuse-window";
         }
 
+        const uri = toFolderUri(project.path);
+
         if (project.type === ProjectType.Folder) {
-            command += ` --folder-uri "${project.path}"`;
+            command += ` --folder-uri "${uri}"`;
         } else {
-            command += ` --file-uri "${project.path}"`;
+            command += ` --file-uri "${uri}"`;
         }
 
         const { NODE_ENV, ...env } = process.env;
-        await execAsync(`${command}`, { env });
+        await execAsync(command, { env: { ...env, PATH: searchPath } });
     } catch (error) {
         console.error(`Error opening project in ${vscodeFlavour}:`, error);
         showToast({
@@ -66,4 +140,4 @@ export async function openProjectInVSCode(project: RecentProject): Promise<void>
             message: `Could not open project in ${vscodeFlavour}`,
         });
     }
-}
+};


### PR DESCRIPTION
Fixes #365.

On macOS the extension shows an empty list, and anything that does show up fails to open with "Command not found". Three separate macOS bugs, plus one cosmetic fix. Full evidence is in the issue; the short version:

### 1. Shared storage path (`src/constants.ts`, `src/helpers.ts`)

The shared storage directory hangs directly off the home directory on **every** platform, not under the per-platform application data directory — VS Code resolves it as `joinPath(userHome, product.sharedDataFolderName)`, and `userHome` is plain `os.homedir()`. The per-platform table added in #272 only produced the right path on Linux.

On macOS the lookup then fell through to the legacy per-flavour DB, which still exists but no longer holds `history.recentlyOpenedPathsList` — so the "database not found" error never fired and the list just came up empty with no diagnostic. The error message now names both paths that were tried, so the next person to hit this gets something to work with.

`VSCODE_SHARED_STATE_PATHS` is replaced by a single `getSharedStateDBPath()`.

### 2. Executable lookup (`src/util/vscode.ts`)

The Vicinae server is launched by LaunchServices, not from a login shell, so extensions inherit `PATH=/usr/bin:/bin:/usr/sbin:/sbin`. The `code` shim lives in `/usr/local/bin` and Homebrew casks use `/opt/homebrew/bin`, so `command -v code` failed every single time and nothing could ever be opened. `exec()` also runs a non-interactive `/bin/sh`, so the user's shell profile doesn't help.

On darwin the search path is now widened, and if the CLI still isn't found we fall back to the one inside the application bundle (`/Applications/<App>.app/Contents/Resources/app/bin/<cli>`), which is there even when the user never ran *Shell Command: Install 'code' command in PATH*. The widened path is passed to the final `exec` too. Non-darwin behaviour is unchanged.

### 3. `--folder-uri` was handed a path, not a URI (`src/util/vscode.ts`)

`decodeFileUri()` strips `file://` and percent-decodes, and the result went straight into `--folder-uri`, which parses its argument as a URI. Plain paths survive, but `#` and `?` truncate — `/tmp/vsr proyecto#uno` silently opened an empty `vsr proyecto` window. Local paths are re-encoded into a proper `file://` URI; anything that already carries a scheme (`vscode-remote://…`) passes through untouched.

### 4. Cosmetic (`src/helpers.ts`)

`getProjectLabel()` appended `.code-workspace` without checking whether the basename already ended in it, giving `MyProject.code-workspace.code-workspace`.

### Deliberately not included

The WAL bug (item 4 in the issue): `sql.js` reads a flat buffer of `state.vscdb` and never sees `state.vscdb-wal`, so the list is stale, and `removeRecentProject()` writes that stale snapshot back over the live DB. It's a real bug, but #202 is already reworking the database layer and I'd rather not collide with it. Happy to send it separately — `node:sqlite` is available unflagged in the extension runtime (Node v22.23.1), reads through the WAL, and would let `sql.js` and its `.wasm` asset go.

### Testing

macOS 15 (Darwin 25.5.0), Vicinae v0.27.0, VS Code 1.134.0.

- Lists 293 valid projects, SSH remotes included; before the fix, zero.
- Opens correctly under the server's exact restricted PATH (`env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin`), verified against both a `code` on PATH and the bundled CLI.
- `/tmp/vsr proyecto#uno` now opens that folder, with its contents, instead of a truncated empty one.
- `npx vici build` clean; `biome format` reports no changes; `package-lock.json` untouched.

I don't have Linux or Windows to hand, so those paths deserve a second pair of eyes — though bug 1 should be a no-op on Linux (same string as before) and bugs 2 and 4 are guarded by `process.platform !== "darwin"`.

One style note: a few existing functions became arrow functions, which widens the diff more than the change warrants. Say the word and I'll put the declarations back.
