### PR TITLE
Add config option for rbw bin for bitwarden extension. Fixes #348 for Mac and other OSes

### DIFF
--- a/extensions/bitwarden/package-lock.json
+++ b/extensions/bitwarden/package-lock.json
@@ -1,10 +1,10 @@
 {
-	"name": "rbw",
+	"name": "bitwarden",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "rbw",
+			"name": "bitwarden",
 			"license": "MIT",
 			"dependencies": {
 				"@vicinae/api": "^0.23.2"
@@ -12,6 +12,7 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.3.2",
 				"@types/node": "^26.1.1",
+				"@types/react": "^19.2.18",
 				"typescript": "^5.9.2"
 			}
 		},
@@ -84,9 +85,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -104,9 +102,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -124,9 +119,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -144,9 +136,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -611,17 +600,19 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
 			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@types/react": {
-			"version": "19.1.17",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
-			"integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+			"version": "19.2.18",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+			"integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@vicinae/api": {
@@ -642,6 +633,15 @@
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
+			}
+		},
+		"node_modules/@vicinae/api/node_modules/@types/react": {
+			"version": "19.1.17",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
+			"integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+			"license": "MIT",
+			"dependencies": {
+				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@vicinae/api/node_modules/typescript": {

--- a/extensions/bitwarden/package.json
+++ b/extensions/bitwarden/package.json
@@ -24,7 +24,16 @@
 			"mode": "view"
 		}
 	],
-	"preferences": [],
+	"preferences": [
+		{
+			"name": "rbwPath",
+			"type": "textfield",
+			"required": false,
+			"title": "rbw bin path",
+			"description": "Path to the rbw bin",
+			"default": "rbw"
+		}
+	],
 	"scripts": {
 		"build": "vici build",
 		"dev": "vici develop",
@@ -37,6 +46,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.3.2",
 		"@types/node": "^26.1.1",
+		"@types/react": "^19.2.18",
 		"typescript": "^5.9.2"
 	}
 }

--- a/extensions/bitwarden/src/browse-vault.tsx
+++ b/extensions/bitwarden/src/browse-vault.tsx
@@ -21,6 +21,7 @@ import {
   listFields,
   isUnlocked,
   syncVault,
+  runRbw,
 } from "./rbw";
 
 type EntryState = { entries: VaultEntry[]; loaded: boolean };
@@ -160,9 +161,7 @@ export default function Command() {
                 onAction={async () => {
                   closeMainWindow();
                   try {
-                    const { execFile } = await import("node:child_process");
-                    const { promisify } = await import("node:util");
-                    await promisify(execFile)("rbw", ["unlock"]);
+                    await runRbw(["unlock"])
                     setLocked(false);
                     await loadEntries();
                   } catch (error) {

--- a/extensions/bitwarden/src/browse-vault.tsx
+++ b/extensions/bitwarden/src/browse-vault.tsx
@@ -139,7 +139,7 @@ export default function Command() {
         <List.EmptyView
           icon={Icon.Warning}
           title="rbw is not installed"
-          description="Install rbw to use this extension. See https://github.com/doy/rbw"
+          description="Install rbw to use this extension. See https://github.com/doy/rbw. Also, try configuring the rbwPath setting in Vicinae settings."
         />
       </List>
     );

--- a/extensions/bitwarden/src/rbw.ts
+++ b/extensions/bitwarden/src/rbw.ts
@@ -1,5 +1,10 @@
+import { getPreferenceValues } from "@vicinae/api";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+
+interface Preferences {
+  rbwPath: string;
+}
 
 const execFileAsync = promisify(execFile);
 
@@ -25,7 +30,7 @@ export class RbwError extends Error {
 export class RbwNotInstalledError extends Error {
   constructor() {
     super(
-      "rbw is not installed. Install it with `pacman -S rbw` (Arch), `brew install rbw` (macOS), or from https://github.com/doy/rbw",
+      "rbw is not installed. Install it with `pacman -S rbw` (Arch), `brew install rbw` (macOS), or from https://github.com/doy/rbw. Also, try configuring the rbwPath setting in Vicinae settings.",
     );
     this.name = "RbwNotInstalledError";
   }
@@ -35,8 +40,9 @@ async function runRbw(
   args: string[],
   options?: { timeout?: number },
 ): Promise<string> {
+  const { rbwPath } = getPreferenceValues<Preferences>();
   try {
-    const { stdout } = await execFileAsync("rbw", args, {
+    const { stdout } = await execFileAsync(rbwPath.trim() ?? "rbw", args, {
       maxBuffer: 4 * 1024 * 1024,
       encoding: "utf-8",
       timeout: options?.timeout ?? 15_000,

--- a/extensions/bitwarden/src/rbw.ts
+++ b/extensions/bitwarden/src/rbw.ts
@@ -36,7 +36,7 @@ export class RbwNotInstalledError extends Error {
   }
 }
 
-async function runRbw(
+export async function runRbw(
   args: string[],
   options?: { timeout?: number },
 ): Promise<string> {


### PR DESCRIPTION
Fixes #348 by just adding a configurable bin path for `rbw`. Also had to add the react types for build to work.

AI Disclosure: no AI used.

Screenshot:
<img width="722" height="362" alt="Bildschirmfoto 2026-08-30 um 2 20 45 PM" src="https://github.com/user-attachments/assets/be9caab8-d881-4abc-9f77-77ea2b4356b5" />
