### PR TITLE
fix: Change nix/silverbullet extension token field type from text to password

### DIFF
--- a/extensions/nix/package.json
+++ b/extensions/nix/package.json
@@ -86,7 +86,7 @@
     {
       "name": "githubToken",
       "description": "GitHub token used for NixOS Packages Pull Requests search",
-      "type": "textfield",
+      "type": "password",
       "required": false,
       "title": "GitHub Token"
     }

--- a/extensions/silverbullet/package.json
+++ b/extensions/silverbullet/package.json
@@ -20,7 +20,7 @@
       "required": true
     },
     {
-      "type": "textfield",
+      "type": "password",
       "title": "Silverbullet API Token",
       "name": "silverbulletApiToken",
       "description": "Your Silverbullet.md API token for Bearer authentication",


### PR DESCRIPTION
After recently staging my Vicinae configuration into a repo, I was informed that two tokens were being stored in plain text. This may be a breaking change. I can't be for certain because I rotated my tokens, so I had to enter them again anyway. 