### PR TITLE
[Bitwarden] add the ability to copy the link of an entry

### DIFF
--- a/extensions/bitwarden/src/browse-vault.tsx
+++ b/extensions/bitwarden/src/browse-vault.tsx
@@ -219,6 +219,7 @@ export default function Command() {
                   <CopyPasswordAction entry={entry} />
                   <CopyUsernameAction entry={entry} />
                   <CopyTotpAction entry={entry} />
+                  <CopyLinkAction entry={entry} />
                 </ActionPanel.Section>
                 <ActionPanel.Section title="Paste to Frontmost App">
                   <PastePasswordAction entry={entry} />
@@ -362,6 +363,39 @@ function CopyTotpAction({ entry }: { entry: VaultEntry }) {
   );
 }
 
+function CopyLinkAction({ entry }: { entry: VaultEntry }) {
+  const uris = entry.uris ?? [];
+  if (uris.length === 0) return null;
+
+  if (uris.length === 1) {
+    return (
+      <Action
+        title="Copy Link"
+        icon={Icon.Link}
+        onAction={async () => {
+          await Clipboard.copy(uris[0], { concealed: true });
+          showToast(Toast.Style.Success, "Copied link");
+        }}
+      />
+    );
+  }
+
+  return (
+    <ActionPanel.Submenu title="Copy Link" icon={Icon.Link}>
+      {uris.map((uri, index) => (
+        <Action
+          key={index}
+          title={uri}
+          onAction={async () => {
+            await Clipboard.copy(uri, { concealed: true });
+            showToast(Toast.Style.Success, "Copied link");
+          }}
+        />
+      ))}
+    </ActionPanel.Submenu>
+  );
+}
+
 function PastePasswordAction({ entry }: { entry: VaultEntry }) {
   return (
     <Action
@@ -478,6 +512,11 @@ function EntryDetailView({ entry }: { entry: VaultEntry }) {
   const markdown = [
     `# ${detail.name}`,
     detail.user ? `**Username:** ${detail.user}` : null,
+    entry.uris && entry.uris.length > 0
+      ? `## Link${entry.uris.length > 1 ? "s" : ""}\n\n${entry.uris
+          .map((uri) => `- [${uri}](<${uri}>)`)
+          .join("\n")}`
+      : null,
     "",
     "## Password",
     `\`\`\`\n${detail.password}\n\`\`\``,


### PR DESCRIPTION
adds an additional copy option for the link of an entry (if available) and also displays it in the details menu of a given entry. 