### PR TITLE
feat: add Pi extension

### DIFF
--- a/extensions/ask-pi/.gitignore
+++ b/extensions/ask-pi/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tgz
+vicinae-env.d.ts

--- a/extensions/ask-pi/README.md
+++ b/extensions/ask-pi/README.md
@@ -1,0 +1,31 @@
+# Pi for Vicinae
+
+Minimal Vicinae UI for an existing [Pi](https://github.com/earendil-works/pi) installation. Pi keeps ownership of models, authentication, tools, skills, configuration, and session history.
+
+## Requirements
+
+- Vicinae 0.28.1 or newer
+- `pi` available on `PATH`
+- Optional on Wayland: `wl-clipboard` for image clipboard support
+
+## Run
+
+```sh
+npm install
+npm run dev
+```
+
+Open **Ask**, enter a request, and press Enter. The extension reads the current clipboard once, starts `pi --mode rpc`, and saves a normal persistent Pi session.
+
+For the `? request` flow, open Vicinae Settings, find the **Ask** command in the **Pi** extension, and set its alias to `?`. Vicinae's alias fast-track moves focus to the command argument after the space, so `? explain this` followed by Enter launches the request directly.
+
+Vicinae does not currently let an extension declare its own root-query prefix. Without the alias, use **Ask → Enter → request → Enter**. The command can also be enabled as a fallback; in that case its root query arrives through Vicinae's `fallbackText` API.
+
+## MVP behavior
+
+- Text clipboard is appended to the user request.
+- Wayland clipboard images are sent through Pi RPC's native `images` field.
+- Only thinking state and compact tool summaries are rendered; tool stdout stays hidden.
+- Open in Pi closes the RPC process, then runs `pi --session <session-file>` in the default terminal.
+- Cancel sends Pi's RPC `abort` command.
+- Interactive prompts from Pi extensions are cancelled because this UI cannot render them yet.

--- a/extensions/ask-pi/assets/pi.svg
+++ b/extensions/ask-pi/assets/pi.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <rect width="800" height="800" rx="120" fill="#09090b"/>
+  <path fill="#fff" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/extensions/ask-pi/package-lock.json
+++ b/extensions/ask-pi/package-lock.json
@@ -1,0 +1,609 @@
+{
+  "name": "ask-pi",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ask-pi",
+      "license": "MIT",
+      "dependencies": {
+        "@vicinae/api": "0.28.1"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "@types/react": "^19.1.17",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@vicinae/api": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@vicinae/api/-/api-0.28.1.tgz",
+      "integrity": "sha512-LUNZ7u7qT0TCfRW2Iqju+WWNc1aA9sggeW8YXx+trWFUGXPoZQfBxtjWo/jnAmE3D2IHEYUXRPym2Ui5hemLCg==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/react": "19.1.17",
+        "chokidar": "^4.0.3",
+        "esbuild": "^0.25.2",
+        "react": "19.1.1",
+        "typescript": "5.9.2",
+        "zod": "^4.0.17"
+      },
+      "bin": {
+        "vici": "dist/bin.js"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@vicinae/api/node_modules/@types/react": {
+      "version": "19.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
+      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@vicinae/api/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/extensions/ask-pi/package.json
+++ b/extensions/ask-pi/package.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/vicinaehq/vicinae/refs/heads/main/extra/schemas/extension.json",
+  "name": "ask-pi",
+  "title": "Pi",
+  "description": "Ask Pi using the current clipboard",
+  "categories": ["Productivity", "Developer Tools"],
+  "license": "MIT",
+  "author": "Forwall100",
+  "icon": "pi.svg",
+  "commands": [
+    {
+      "name": "ask",
+      "title": "Ask",
+      "description": "Send a request and the current clipboard to Pi",
+      "mode": "view",
+      "arguments": [
+        {
+          "type": "text",
+          "name": "prompt",
+          "placeholder": "Ask Pi",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "scripts": {
+    "build": "vici build",
+    "dev": "vici develop",
+    "lint": "vici lint",
+    "test": "node --no-warnings --test src/pi.test.ts"
+  },
+  "dependencies": {
+    "@vicinae/api": "0.28.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "@types/react": "^19.1.17",
+    "typescript": "^5.9.2"
+  }
+}

--- a/extensions/ask-pi/src/ask.tsx
+++ b/extensions/ask-pi/src/ask.tsx
@@ -4,9 +4,11 @@ import {
   Clipboard,
   Detail,
   Icon,
+  Toast,
   type LaunchProps,
   closeMainWindow,
   runInTerminal,
+  showToast,
 } from "@vicinae/api";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { PiRpc, type PiEvent, type PiImage, readWaylandImage, toolSummary } from "./pi";
@@ -115,20 +117,29 @@ export default function AskPi(props: Props) {
   const cancel = async () => {
     cancelled.current = true;
     request.current++;
-    setPhase("cancelled");
-    setStatus("Cancelled");
+    setStatus("Cancelling…");
     try {
       await rpc.current?.abort();
     } catch {
-      // The process may have exited at the same time.
+      await rpc.current?.close();
     }
+    setPhase("cancelled");
+    setStatus("Cancelled");
   };
 
   const openInPi = async () => {
     if (!sessionFile) return;
-    await rpc.current?.close();
-    await runInTerminal(["pi", "--session", sessionFile], { title: "Pi" });
-    await closeMainWindow();
+    try {
+      await rpc.current?.close();
+      await runInTerminal(["pi", "--session", sessionFile], { title: "Pi" });
+      await closeMainWindow();
+    } catch (cause) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Could not open Pi",
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+    }
   };
 
   const activity = tools.length

--- a/extensions/ask-pi/src/ask.tsx
+++ b/extensions/ask-pi/src/ask.tsx
@@ -1,0 +1,168 @@
+import {
+  Action,
+  ActionPanel,
+  Clipboard,
+  Detail,
+  Icon,
+  type LaunchProps,
+  closeMainWindow,
+  runInTerminal,
+} from "@vicinae/api";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { PiRpc, type PiEvent, type PiImage, readWaylandImage, toolSummary } from "./pi";
+
+type Props = LaunchProps<{ arguments: { prompt?: string } }>;
+type Phase = "starting" | "running" | "done" | "cancelled" | "error";
+type Tool = { id: string; label: string; done: boolean };
+
+function promptWithClipboard(prompt: string, text?: string, image?: PiImage) {
+  if (image) return `${prompt}\n\nThe current clipboard image is attached as additional context.`;
+  if (text) return `${prompt}\n\n--- Current clipboard (additional context) ---\n${text}`;
+  return `${prompt}\n\nThe current clipboard is empty.`;
+}
+
+export default function AskPi(props: Props) {
+  const rpc = useRef<PiRpc | undefined>(undefined);
+  const request = useRef(0);
+  const cancelled = useRef(false);
+  const [phase, setPhase] = useState<Phase>("starting");
+  const [status, setStatus] = useState("Reading clipboard…");
+  const [clipboard, setClipboard] = useState("Checking…");
+  const [tools, setTools] = useState<Tool[]>([]);
+  const [answer, setAnswer] = useState("");
+  const [error, setError] = useState("");
+  const [sessionFile, setSessionFile] = useState("");
+
+  const onEvent = useCallback((event: PiEvent) => {
+    if (event.type === "message_update") {
+      const update = event.assistantMessageEvent as { type?: string } | undefined;
+      if (update?.type === "thinking_start") setStatus("Thinking…");
+      if (update?.type === "text_start") setStatus("Writing answer…");
+    }
+
+    if (event.type === "tool_execution_start") {
+      const id = String(event.toolCallId);
+      const name = String(event.toolName);
+      const label = toolSummary(name, event.args as Record<string, unknown>);
+      setStatus(`Using ${name}…`);
+      setTools((current) => [...current.filter((tool) => tool.id !== id), { id, label, done: false }].slice(-6));
+    }
+
+    if (event.type === "tool_execution_end") {
+      const id = String(event.toolCallId);
+      setTools((current) => current.map((tool) => (tool.id === id ? { ...tool, done: true } : tool)));
+      setStatus("Thinking…");
+    }
+  }, []);
+
+  const runPrompt = useCallback(async (client: PiRpc, prompt: string, images?: PiImage[]) => {
+    const current = ++request.current;
+    cancelled.current = false;
+    setPhase("running");
+    setStatus("Thinking…");
+    setTools([]);
+    setError("");
+
+    try {
+      const result = await client.prompt(prompt, images);
+      if (current !== request.current) return;
+      setAnswer(result || "Pi completed without a text response.");
+      setStatus("Done");
+      setPhase("done");
+    } catch (cause) {
+      if (current !== request.current) return;
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setStatus("Failed");
+      setPhase("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+
+    void (async () => {
+      try {
+        const image = await readWaylandImage();
+        const text = image ? "" : await Clipboard.readText();
+        if (disposed || cancelled.current) return;
+
+        setClipboard(image ? `Image · ${image.mimeType}` : text ? "Text" : "Empty");
+        setStatus("Starting Pi…");
+        const client = new PiRpc(onEvent);
+        rpc.current = client;
+        const state = await client.state();
+        if (disposed || cancelled.current) return void client.close();
+        setSessionFile(state.sessionFile || "");
+
+        const fallback = props.fallbackText?.replace(/^\?\s*/, "").trim();
+        const prompt = fallback || props.arguments?.prompt?.trim();
+        if (!prompt) throw new Error("Enter a request for Pi");
+        void runPrompt(client, promptWithClipboard(prompt, text, image), image ? [image] : undefined);
+      } catch (cause) {
+        if (disposed) return;
+        setError(cause instanceof Error ? cause.message : String(cause));
+        setStatus("Failed");
+        setPhase("error");
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      void rpc.current?.close();
+    };
+  }, [onEvent, props.arguments?.prompt, props.fallbackText, runPrompt]);
+
+  const cancel = async () => {
+    cancelled.current = true;
+    request.current++;
+    setPhase("cancelled");
+    setStatus("Cancelled");
+    try {
+      await rpc.current?.abort();
+    } catch {
+      // The process may have exited at the same time.
+    }
+  };
+
+  const openInPi = async () => {
+    if (!sessionFile) return;
+    await rpc.current?.close();
+    await runInTerminal(["pi", "--session", sessionFile], { title: "Pi" });
+    await closeMainWindow();
+  };
+
+  const activity = tools.length
+    ? `### Activity\n\n${tools.map((tool) => `- ${tool.done ? "✓" : "→"} ${tool.label}`).join("\n")}`
+    : "_No tool calls yet._";
+  const markdown =
+    phase === "done"
+      ? answer
+      : phase === "error"
+        ? `## Pi could not finish\n\n${error}`
+        : `## ${status}\n\n${activity}`;
+
+  return (
+    <Detail
+      navigationTitle="Pi"
+      markdown={markdown}
+      metadata={
+        <Detail.Metadata>
+          <Detail.Metadata.Label title="Status" text={status} />
+          <Detail.Metadata.Label title="Clipboard" text={clipboard} />
+        </Detail.Metadata>
+      }
+      actions={
+        <ActionPanel>
+          {phase === "running" || phase === "starting" ? (
+            <Action title="Cancel" icon={Icon.Stop} style="destructive" onAction={() => void cancel()} />
+          ) : (
+            <>
+              {phase === "done" && <Action.CopyToClipboard title="Copy Answer" content={answer} />}
+              {sessionFile && <Action title="Open in Pi" icon={Icon.Terminal} onAction={() => void openInPi()} />}
+            </>
+          )}
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/ask-pi/src/pi.test.ts
+++ b/extensions/ask-pi/src/pi.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assistantError, takeJsonLines, toolSummary } from "./pi.ts";
+
+test("Pi JSONL keeps partial and Unicode-separator data intact", () => {
+  const first = takeJsonLines("", '{"type":"message_update","text":"a\u2028b"}\n{"type"');
+  assert.equal(first.values[0].text, "a\u2028b");
+  assert.equal(first.buffer, '{"type"');
+
+  const second = takeJsonLines(first.buffer, ':"agent_settled"}\r\n');
+  assert.deepEqual(second.values, [{ type: "agent_settled" }]);
+  assert.equal(second.buffer, "");
+});
+
+test("tool summaries stay compact and omit output", () => {
+  assert.equal(toolSummary("grep", { pattern: "TODO", path: "src" }), "grep · TODO · src");
+  assert.equal(toolSummary("bash", { command: "npm test\necho noisy" }), "bash · npm test");
+});
+
+test("the final assistant result clears or exposes provider errors", () => {
+  const failed = assistantError({
+    type: "message_end",
+    message: { role: "assistant", stopReason: "error", errorMessage: "Connection error." },
+  });
+  assert.equal(failed, "Connection error.");
+  assert.equal(assistantError({ type: "agent_settled" }, failed), "Connection error.");
+  assert.equal(assistantError({ type: "message_end", message: { role: "assistant", stopReason: "stop" } }, failed), "");
+});

--- a/extensions/ask-pi/src/pi.ts
+++ b/extensions/ask-pi/src/pi.ts
@@ -1,0 +1,207 @@
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+
+export type PiImage = { type: "image"; data: string; mimeType: string };
+export type PiEvent = Record<string, unknown> & { type?: string };
+
+export function assistantError(event: PiEvent, current = "") {
+  if (event.type !== "message_end") return current;
+  const message = event.message as PiEvent | undefined;
+  if (message?.role !== "assistant") return current;
+  return message.stopReason === "error" ? String(message.errorMessage || "Pi failed") : "";
+}
+
+type Pending = {
+  resolve: (value: Record<string, unknown>) => void;
+  reject: (error: Error) => void;
+};
+
+export function takeJsonLines(buffer: string, chunk: string) {
+  const lines = (buffer + chunk).split("\n");
+  return {
+    buffer: lines.pop() ?? "",
+    values: lines.filter(Boolean).map((line) => JSON.parse(line.endsWith("\r") ? line.slice(0, -1) : line)),
+  };
+}
+
+export function toolSummary(name: string, args: Record<string, unknown> = {}) {
+  const oneLine = (value: unknown) => String(value ?? "").split("\n", 1)[0].trim();
+  let detail = "";
+
+  if (name === "grep") {
+    detail = [oneLine(args.pattern), oneLine(args.path)].filter(Boolean).join(" · ");
+  } else if (name === "bash") {
+    detail = oneLine(args.command);
+  } else {
+    detail = oneLine(args.path ?? args.file_path ?? args.pattern ?? args.query);
+  }
+
+  return detail ? `${name} · ${detail.slice(0, 90)}` : name;
+}
+
+function execBuffer(command: string, args: string[], maxBuffer: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { encoding: "buffer", maxBuffer }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(Buffer.from(stdout));
+    });
+  });
+}
+
+export async function readWaylandImage(): Promise<PiImage | undefined> {
+  let advertised: string;
+
+  try {
+    advertised = (await execBuffer("wl-paste", ["--list-types"], 64 * 1024)).toString("utf8");
+  } catch {
+    return undefined;
+  }
+
+  const mimeType = ["image/png", "image/jpeg", "image/webp", "image/gif"].find((mime) =>
+    advertised.split(/\r?\n/).includes(mime),
+  );
+  if (!mimeType) return undefined;
+
+  const data = await execBuffer("wl-paste", ["--no-newline", "--type", mimeType], 25 * 1024 * 1024);
+  return { type: "image", data: data.toString("base64"), mimeType };
+}
+
+export class PiRpc {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly pending = new Map<string, Pending>();
+  private readonly decoder = new StringDecoder("utf8");
+  private buffer = "";
+  private sequence = 0;
+  private settled?: Pending;
+  private stderr = "";
+  private agentError = "";
+  private closed = false;
+  private readonly onEvent: (event: PiEvent) => void;
+
+  constructor(onEvent: (event: PiEvent) => void) {
+    this.onEvent = onEvent;
+    this.child = spawn("pi", ["--mode", "rpc"], {
+      cwd: process.env.HOME || process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child.stdout.on("data", (chunk: Buffer) => this.read(chunk));
+    this.child.stderr.on("data", (chunk: Buffer) => {
+      this.stderr = (this.stderr + chunk.toString("utf8")).slice(-4000);
+    });
+    this.child.on("error", (error) =>
+      this.fail(
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+          ? new Error("Pi is not installed or is not available on PATH.")
+          : error,
+      ),
+    );
+    this.child.on("close", (code) => {
+      if (!this.closed) this.fail(new Error(this.stderr.trim() || `Pi exited with code ${code}`));
+    });
+  }
+
+  async state() {
+    const response = await this.request({ type: "get_state" });
+    return response.data as { sessionFile?: string };
+  }
+
+  async prompt(message: string, images?: PiImage[]) {
+    if (this.settled) throw new Error("Pi is already running");
+    this.agentError = "";
+
+    const settled = new Promise<Record<string, unknown>>((resolve, reject) => {
+      this.settled = { resolve, reject };
+    });
+
+    try {
+      await this.request({ type: "prompt", message, ...(images?.length ? { images } : {}) });
+      await settled;
+      const response = await this.request({ type: "get_last_assistant_text" });
+      return ((response.data as { text?: string | null })?.text ?? "").trim();
+    } catch (error) {
+      this.settled = undefined;
+      throw error;
+    }
+  }
+
+  abort() {
+    return this.request({ type: "abort" });
+  }
+
+  async close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.fail(new Error("Pi session closed"));
+    this.child.stdin.end();
+
+    await new Promise<void>((resolve) => {
+      if (this.child.exitCode !== null) return resolve();
+      const timer = setTimeout(() => {
+        this.child.kill();
+        resolve();
+      }, 1000);
+      this.child.once("close", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  private request(command: Record<string, unknown>) {
+    if (this.closed) return Promise.reject(new Error("Pi session is closed"));
+    const id = `vicinae-${++this.sequence}`;
+
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.child.stdin.write(`${JSON.stringify({ id, ...command })}\n`, (error) => {
+        if (error) {
+          this.pending.delete(id);
+          reject(error);
+        }
+      });
+    });
+  }
+
+  private read(chunk: Buffer) {
+    let parsed: ReturnType<typeof takeJsonLines>;
+    try {
+      parsed = takeJsonLines(this.buffer, this.decoder.write(chunk));
+    } catch (cause) {
+      this.fail(new Error(`Invalid response from Pi: ${cause instanceof Error ? cause.message : String(cause)}`));
+      this.child.kill();
+      return;
+    }
+    this.buffer = parsed.buffer;
+
+    for (const event of parsed.values as PiEvent[]) {
+      this.agentError = assistantError(event, this.agentError);
+
+      if (event.type === "response" && typeof event.id === "string") {
+        const pending = this.pending.get(event.id);
+        if (!pending) continue;
+        this.pending.delete(event.id);
+        if (event.success === false) pending.reject(new Error(String(event.error || "Pi command failed")));
+        else pending.resolve(event);
+      } else if (event.type === "agent_settled") {
+        if (this.agentError) this.settled?.reject(new Error(this.agentError));
+        else this.settled?.resolve(event);
+        this.settled = undefined;
+      } else if (
+        event.type === "extension_ui_request" &&
+        typeof event.id === "string" &&
+        ["select", "confirm", "input", "editor"].includes(String(event.method))
+      ) {
+        this.child.stdin.write(`${JSON.stringify({ type: "extension_ui_response", id: event.id, cancelled: true })}\n`);
+      } else {
+        this.onEvent(event);
+      }
+    }
+  }
+
+  private fail(error: Error) {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+    this.settled?.reject(error);
+    this.settled = undefined;
+  }
+}

--- a/extensions/ask-pi/tsconfig.json
+++ b/extensions/ask-pi/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "strict": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "jsx": "react-jsx",
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Overview

  Adds a minimal Vicinae interface for sending a prompt and the current clipboard to an existing Pi
  installation.

  ## Features

  - Sends text and Wayland clipboard images to Pi through RPC mode
  - Shows thinking state and compact tool activity
  - Supports cancelling the current request
  - Opens the persistent session in Pi
  - Supports command arguments, aliases, and fallback text

  ## Requirements

  - Pi available on `PATH`
  - Optional: `wl-clipboard` for Wayland image support

  ## Testing

  - `npm test`
  - `npm run lint`
  - `bunx vici build --out ../../dist/ask-pi`

  All checks pass locally.

  ## Known limitation

  Interactive prompts requested by Pi extensions are cancelled because the Vicinae view cannot render them yet.

  ## AI disclosure

  Developed and reviewed with OpenAI Codex.